### PR TITLE
feat: Hdpi 143 idam retry

### DIFF
--- a/src/main/modules/oidc/oidc.ts
+++ b/src/main/modules/oidc/oidc.ts
@@ -13,7 +13,6 @@ export class OIDCModule {
   private readonly logger = Logger.getLogger('oidc');
 
   private async setupClient(): Promise<void> {
-    
     this.logger.info('setting up client');
 
     try {

--- a/src/main/modules/oidc/oidc.ts
+++ b/src/main/modules/oidc/oidc.ts
@@ -12,6 +12,10 @@ export class OIDCModule {
   private oidcConfig: OIDCConfig = config.get<OIDCConfig>('oidc');
   private readonly logger = Logger.getLogger('oidc');
 
+  constructor() {
+    this.setupClient();
+  }
+
   private async setupClient(): Promise<void> {
     this.logger.info('setting up client');
 

--- a/src/main/modules/oidc/oidc.ts
+++ b/src/main/modules/oidc/oidc.ts
@@ -9,12 +9,8 @@ import { OIDCAuthenticationError, OIDCCallbackError } from './errors';
 
 export class OIDCModule {
   private clientConfig!: Configuration;
-  private oidcConfig!: OIDCConfig;
+  private oidcConfig: OIDCConfig = config.get<OIDCConfig>('oidc');
   private readonly logger = Logger.getLogger('oidc');
-
-  constructor() {
-    this.oidcConfig = config.get<OIDCConfig>('oidc');
-  }
 
   private async setupClient(): Promise<void> {
     
@@ -54,7 +50,7 @@ export class OIDCModule {
 
     app.use(async (req: Request, res: Response, next: NextFunction) => {
       if (!this.clientConfig) {
-        this.logger.error('Client config not found, retrying...');
+        this.logger.error('Client config not found, retrieving...');
         await this.setupClient();
       }
       next();
@@ -79,8 +75,6 @@ export class OIDCModule {
           parameters.nonce = req.session.nonce;
         }
 
-        this.logger.info('parameters =>>>>>> ', parameters);
-
         const redirectTo = client.buildAuthorizationUrl(this.clientConfig, parameters);
         res.redirect(redirectTo.href);
       } catch (error) {
@@ -93,9 +87,6 @@ export class OIDCModule {
     app.get('/oauth2/callback', async (req: Request, res: Response, next: NextFunction) => {
       try {
         const { codeVerifier, nonce } = req.session;
-
-        this.logger.info('codeVerifier =>>>>>> ', codeVerifier);
-        this.logger.info('nonce =>>>>>> ', nonce);
 
         const callbackUrl = OIDCModule.getCurrentUrl(req);
 

--- a/src/main/modules/oidc/oidc.ts
+++ b/src/main/modules/oidc/oidc.ts
@@ -33,6 +33,7 @@ export class OIDCModule {
       );
     } catch (error) {
       this.logger.error('Failed to setup OIDC client:', error);
+      throw new OIDCAuthenticationError('Failed to initialize OIDC client');
     }
   }
 
@@ -49,8 +50,12 @@ export class OIDCModule {
 
     app.use(async (req: Request, res: Response, next: NextFunction) => {
       if (!this.clientConfig) {
-        this.logger.error('Client config not found, retrieving...');
-        await this.setupClient();
+        try {
+          this.logger.error('Client config not found, retrieving...');
+          await this.setupClient();
+        } catch (error) {
+          next(error);
+        }
       }
       next();
     });

--- a/src/test/unit/modules/oidc/oidc.test.ts
+++ b/src/test/unit/modules/oidc/oidc.test.ts
@@ -82,6 +82,7 @@ describe('OIDCModule', () => {
     mockApp = {
       get: jest.fn(),
       set: jest.fn(),
+      use: jest.fn(),
       locals: {
         nunjucksEnv: {
           addGlobal: jest.fn(),
@@ -171,6 +172,7 @@ describe('OIDCModule', () => {
         mockApp = {
           get: jest.fn(),
           set: jest.fn(),
+          use: jest.fn(),
           locals: {
             nunjucksEnv: {
               addGlobal: jest.fn(),


### PR DESCRIPTION
introduced a middleware in OIDC module, so if the client wasn't successfully configured upon instantiation it would retry indefinitely per request.