### PR TITLE
HouseKeeping - modal timeout config change

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -13,7 +13,7 @@
     },
     "timeout": {
       "sessionWarningMinutes": 5,
-      "sessionTimeoutMinutes": 6,
+      "sessionTimeoutMinutes": 90,
       "checkIntervalSeconds": 10
     }
   },


### PR DESCRIPTION
### Jira link

See [HDPI-3615](https://tools.hmcts.net/jira/browse/HDPI-3615)

### Change description

Updated modal config from 6 mins to 90mins. 
This ticket has already been tested and been through dev assurance please se: [HDPI-2952](https://tools.hmcts.net/jira/browse/HDPI-2952)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
