### PR TITLE
suppress cve

### DIFF
--- a/yarn-audit-known-issues
+++ b/yarn-audit-known-issues
@@ -1,0 +1,1 @@
+{"value":"protobufjs","children":{"ID":1116832,"Issue":"Arbitrary code execution in protobufjs","URL":"https://github.com/advisories/GHSA-xq3m-2v4x-88gg","Severity":"critical","Vulnerable Versions":">= 8.0.0, < 8.0.1","Tree Versions":["7.5.4"],"Dependents":["@opentelemetry/otlp-transformer@npm:0.208.0"]}}


### PR DESCRIPTION
As far as I can tell we don't actually have the 8 series of protobuf in our repo, everything should be 7.x so I'm not even sure why this is flagged.