### PR TITLE
HDPI-5548: scope step i18n namespaces by journey

### DIFF
--- a/src/main/modules/steps/controller.ts
+++ b/src/main/modules/steps/controller.ts
@@ -35,13 +35,12 @@ export const createGetController = (
   view: string,
   stepName: string,
   stepNavigation: StepNavigation,
-  extendContent?: (req: Request) => StepFormData | Promise<StepFormData>,
-  journeyFolder?: string
+  extendContent?: (req: Request) => StepFormData | Promise<StepFormData>
 ): GetController => {
   return new GetController(view, async (req: Request) => {
-    if (journeyFolder && req.i18n) {
+    if (req.i18n) {
       try {
-        await loadStepNamespace(req, stepName, journeyFolder);
+        await loadStepNamespace(req);
       } catch (error) {
         logger.warn(`Failed to load namespace for step ${stepName}:`, error);
       }
@@ -51,15 +50,13 @@ export const createGetController = (
     const postData = req.body || {};
     const lang = getRequestLanguage(req);
 
-    const t: TFunction = journeyFolder
-      ? getTranslationFunction(req, stepName, ['common'])
-      : getTranslationFunction(req);
+    const t: TFunction = getTranslationFunction(req);
 
     req.t = t;
 
     const selected = formData?.answer || formData?.choices || postData.answer || postData.choices;
 
-    const stepTranslations = journeyFolder ? getStepTranslations(req, stepName) : {};
+    const stepTranslations = getStepTranslations(req);
     const commonTranslations = req.i18n?.getResourceBundle(lang, 'common') || {};
     const commonContent: Record<string, unknown> = {};
     for (const key of ['change', 'buttons']) {
@@ -107,23 +104,20 @@ export const createPostController = (
   stepNavigation: StepNavigation,
   getFields: (t: TFunction) => FormFieldConfig[],
   view: string,
-  beforeRedirect?: PostControllerCallback,
-  journeyFolder?: string
+  beforeRedirect?: PostControllerCallback
 ): { post: (req: Request, res: Response, next: NextFunction) => Promise<void | Response> } => {
   return {
     post: async (req: Request, res: Response, next: NextFunction) => {
-      if (journeyFolder && req.i18n) {
+      if (req.i18n) {
         try {
-          await loadStepNamespace(req, stepName, journeyFolder);
+          await loadStepNamespace(req);
         } catch (error) {
           logger.warn(`Failed to load namespace for step ${stepName}:`, error);
         }
       }
 
       const reqLang = getRequestLanguage(req);
-      const t: TFunction = journeyFolder
-        ? getTranslationFunction(req, stepName, ['common'])
-        : getTranslationFunction(req);
+      const t: TFunction = getTranslationFunction(req);
 
       const fields = getFields(t);
       const errors = validateForm(req, fields);

--- a/src/main/modules/steps/formBuilder/errorUtils.ts
+++ b/src/main/modules/steps/formBuilder/errorUtils.ts
@@ -142,7 +142,7 @@ export async function renderWithErrors(
   showCancelButton?: boolean
 ): Promise<void> {
   const lang = getRequestLanguage(req);
-  const t: TFunction = getTranslationFunction(req, stepName, ['common']);
+  const t: TFunction = getTranslationFunction(req);
 
   const navigationBackUrl = await navigation.getBackUrl(req, stepName);
   const backUrl = typeof formContent.backUrl === 'string' ? formContent.backUrl : navigationBackUrl;

--- a/src/main/modules/steps/formBuilder/index.ts
+++ b/src/main/modules/steps/formBuilder/index.ts
@@ -76,9 +76,9 @@ export function createFormStep(config: FormBuilderConfig): StepDefinition {
     documentStorage,
     getController: () => {
       return createGetController(viewPath, stepName, stepNavigation, async req => {
-        await loadStepNamespace(req, stepName, journeyFolder);
+        await loadStepNamespace(req);
 
-        const t: TFunction = getTranslationFunction(req, stepName, ['common']);
+        const t: TFunction = getTranslationFunction(req);
 
         const nunjucksEnv = req.app.locals.nunjucksEnv;
         if (!nunjucksEnv) {

--- a/src/main/modules/steps/formBuilder/postHandler.ts
+++ b/src/main/modules/steps/formBuilder/postHandler.ts
@@ -57,9 +57,9 @@ export function createPostHandler(
 
   return {
     post: async (req: Request, res: Response, next: NextFunction) => {
-      await loadStepNamespace(req, stepName, journeyFolder);
+      await loadStepNamespace(req);
 
-      const t: TFunction = getTranslationFunction(req, stepName, ['common']);
+      const t: TFunction = getTranslationFunction(req);
       const action = req.body.action as string | undefined;
 
       const nunjucksEnv = req.app.locals.nunjucksEnv;

--- a/src/main/modules/steps/i18n.ts
+++ b/src/main/modules/steps/i18n.ts
@@ -12,8 +12,6 @@ import {
   getTranslationFunction as getMainTranslationFunction,
 } from '../i18n';
 
-import { getStepContext } from './stepContext';
-
 import { Logger } from '@modules/logger';
 
 const logger = Logger.getLogger('i18n');
@@ -77,14 +75,6 @@ function getStepTranslationPaths(req: Request, stepName: string, folder: string)
   return [defaultPath, getStepTranslationPath(stepName, `${folder}/${userType}`)];
 }
 
-function resolveStepName(req: Request, explicit?: string): string | undefined {
-  return explicit ?? getStepContext(req)?.name;
-}
-
-function resolveJourneyFolder(req: Request, explicit?: string): string | undefined {
-  return explicit ?? getStepContext(req)?.journey;
-}
-
 /**
  * Loads and registers a step's translations under a journey-scoped i18next
  * namespace. The early-return cache check is safe because the namespace is
@@ -99,8 +89,8 @@ export async function loadStepNamespace(req: Request, stepName?: string, folder?
     return;
   }
 
-  const resolvedStepName = resolveStepName(req, stepName);
-  const resolvedFolder = resolveJourneyFolder(req, folder);
+  const resolvedStepName = stepName ?? req.res?.locals.step?.name;
+  const resolvedFolder = folder ?? req.res?.locals.step?.journey;
 
   if (!resolvedStepName || !resolvedFolder) {
     return;
@@ -176,8 +166,8 @@ export function getStepTranslations(req: Request, stepName?: string, journeyFold
     return {};
   }
 
-  const resolvedStepName = resolveStepName(req, stepName);
-  const resolvedFolder = resolveJourneyFolder(req, journeyFolder);
+  const resolvedStepName = stepName ?? req.res?.locals.step?.name;
+  const resolvedFolder = journeyFolder ?? req.res?.locals.step?.journey;
   if (!resolvedStepName || !resolvedFolder) {
     return {};
   }
@@ -202,8 +192,8 @@ export function getTranslationFunction(
     return getMainTranslationFunction(req, namespaces);
   }
 
-  const resolvedStepName = resolveStepName(req, stepName);
-  const resolvedFolder = resolveJourneyFolder(req, journeyFolder);
+  const resolvedStepName = stepName ?? req.res?.locals.step?.name;
+  const resolvedFolder = journeyFolder ?? req.res?.locals.step?.journey;
 
   const lang = getMainRequestLanguage(req);
   const allNamespaces =

--- a/src/main/modules/steps/i18n.ts
+++ b/src/main/modules/steps/i18n.ts
@@ -56,16 +56,12 @@ function camelizeStepName(stepName: string): string {
 }
 
 /**
- * i18next namespace for a step. Scoped by the journey folder so that two
- * journeys with the same step name (e.g. two `start-now` steps) get distinct
- * namespaces and don't share a single mutable bundle.
+ * Identity for a step's translations. Used as both the locales filesystem path
+ * (under `locales/<lang>/`) and the i18next namespace — one identity, one
+ * function. The journey folder is required so that two journeys with the same
+ * step name (e.g. two `start-now` steps) get distinct namespaces and don't
+ * share a single mutable bundle.
  */
-export function getStepNamespace(stepName: string, journeyFolder?: string): string {
-  const camel = camelizeStepName(stepName);
-  return journeyFolder ? `${journeyFolder}__${camel}` : camel;
-}
-
-/** Filesystem path (without extension) for a step's translation file under locales/<lang>/. */
 export function getStepTranslationPath(stepName: string, folder: string): string {
   return `${folder}/${camelizeStepName(stepName)}`;
 }
@@ -78,7 +74,7 @@ function getStepTranslationPaths(req: Request, stepName: string, folder: string)
     return [defaultPath];
   }
 
-  return [defaultPath, `${folder}/${userType}/${camelizeStepName(stepName)}`];
+  return [defaultPath, getStepTranslationPath(stepName, `${folder}/${userType}`)];
 }
 
 function resolveStepName(req: Request, explicit?: string): string | undefined {
@@ -110,7 +106,7 @@ export async function loadStepNamespace(req: Request, stepName?: string, folder?
     return;
   }
 
-  const stepNamespace = getStepNamespace(resolvedStepName, resolvedFolder);
+  const stepNamespace = getStepTranslationPath(resolvedStepName, resolvedFolder);
   const lang = getMainRequestLanguage(req);
 
   if (req.i18n.getResourceBundle(lang, stepNamespace)) {
@@ -181,13 +177,13 @@ export function getStepTranslations(req: Request, stepName?: string, journeyFold
   }
 
   const resolvedStepName = resolveStepName(req, stepName);
-  if (!resolvedStepName) {
+  const resolvedFolder = resolveJourneyFolder(req, journeyFolder);
+  if (!resolvedStepName || !resolvedFolder) {
     return {};
   }
 
-  const resolvedFolder = resolveJourneyFolder(req, journeyFolder);
   const lang = getMainRequestLanguage(req);
-  const resources = req.i18n.getResourceBundle(lang, getStepNamespace(resolvedStepName, resolvedFolder));
+  const resources = req.i18n.getResourceBundle(lang, getStepTranslationPath(resolvedStepName, resolvedFolder));
   return (resources as TranslationContent) || {};
 }
 
@@ -210,9 +206,10 @@ export function getTranslationFunction(
   const resolvedFolder = resolveJourneyFolder(req, journeyFolder);
 
   const lang = getMainRequestLanguage(req);
-  const allNamespaces = resolvedStepName
-    ? [getStepNamespace(resolvedStepName, resolvedFolder), ...namespaces]
-    : namespaces;
+  const allNamespaces =
+    resolvedStepName && resolvedFolder
+      ? [getStepTranslationPath(resolvedStepName, resolvedFolder), ...namespaces]
+      : namespaces;
   const fixedT = req.i18n.getFixedT(lang, allNamespaces);
   return fixedT || getMainTranslationFunction(req, namespaces);
 }

--- a/src/main/modules/steps/i18n.ts
+++ b/src/main/modules/steps/i18n.ts
@@ -12,6 +12,8 @@ import {
   getTranslationFunction as getMainTranslationFunction,
 } from '../i18n';
 
+import { getStepContext } from './stepContext';
+
 import { Logger } from '@modules/logger';
 
 const logger = Logger.getLogger('i18n');
@@ -46,15 +48,26 @@ function mergeTranslations(
   return merged;
 }
 
-export function getStepNamespace(stepName: string): string {
+function camelizeStepName(stepName: string): string {
   return stepName
     .split('-')
     .map((part, index) => (index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
     .join('');
 }
 
+/**
+ * i18next namespace for a step. Scoped by the journey folder so that two
+ * journeys with the same step name (e.g. two `start-now` steps) get distinct
+ * namespaces and don't share a single mutable bundle.
+ */
+export function getStepNamespace(stepName: string, journeyFolder?: string): string {
+  const camel = camelizeStepName(stepName);
+  return journeyFolder ? `${journeyFolder}__${camel}` : camel;
+}
+
+/** Filesystem path (without extension) for a step's translation file under locales/<lang>/. */
 export function getStepTranslationPath(stepName: string, folder: string): string {
-  return `${folder}/${getStepNamespace(stepName)}`;
+  return `${folder}/${camelizeStepName(stepName)}`;
 }
 
 function getStepTranslationPaths(req: Request, stepName: string, folder: string): string[] {
@@ -65,21 +78,49 @@ function getStepTranslationPaths(req: Request, stepName: string, folder: string)
     return [defaultPath];
   }
 
-  return [defaultPath, `${folder}/${userType}/${getStepNamespace(stepName)}`];
+  return [defaultPath, `${folder}/${userType}/${camelizeStepName(stepName)}`];
 }
 
-export async function loadStepNamespace(req: Request, stepName: string, folder: string): Promise<void> {
+function resolveStepName(req: Request, explicit?: string): string | undefined {
+  return explicit ?? getStepContext(req)?.name;
+}
+
+function resolveJourneyFolder(req: Request, explicit?: string): string | undefined {
+  return explicit ?? getStepContext(req)?.journey;
+}
+
+/**
+ * Loads and registers a step's translations under a journey-scoped i18next
+ * namespace. The early-return cache check is safe because the namespace is
+ * unique per (journey, step), so the first request warms it and subsequent
+ * requests skip the disk read.
+ *
+ * `stepName` and `folder` are optional — when omitted they're read from
+ * `res.locals.step` (set by `withStepContext` middleware in registerSteps).
+ */
+export async function loadStepNamespace(req: Request, stepName?: string, folder?: string): Promise<void> {
   if (!req.i18n) {
     return;
   }
 
-  const stepNamespace = getStepNamespace(stepName);
+  const resolvedStepName = resolveStepName(req, stepName);
+  const resolvedFolder = resolveJourneyFolder(req, folder);
+
+  if (!resolvedStepName || !resolvedFolder) {
+    return;
+  }
+
+  const stepNamespace = getStepNamespace(resolvedStepName, resolvedFolder);
   const lang = getMainRequestLanguage(req);
+
+  if (req.i18n.getResourceBundle(lang, stepNamespace)) {
+    return;
+  }
 
   const localesDir = await findLocalesDir();
   if (!localesDir) {
     if (isDevelopment) {
-      logger.warn(`Locales directory not found. Translation file for ${stepName} will not be loaded.`);
+      logger.warn(`Locales directory not found. Translation file for ${resolvedStepName} will not be loaded.`);
     }
     return;
   }
@@ -87,7 +128,7 @@ export async function loadStepNamespace(req: Request, stepName: string, folder: 
   try {
     let translations: Record<string, unknown> = {};
 
-    for (const translationPath of getStepTranslationPaths(req, stepName, folder)) {
+    for (const translationPath of getStepTranslationPaths(req, resolvedStepName, resolvedFolder)) {
       const filePath = path.join(localesDir, lang, `${translationPath}.json`);
       const resolvedPath = path.resolve(filePath);
       const resolvedLocalesDir = path.resolve(localesDir);
@@ -124,30 +165,54 @@ export async function loadStepNamespace(req: Request, stepName: string, folder: 
     if (isDevelopment) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       if (!errorMessage.includes('ENOENT')) {
-        logger.error(`Failed to load translation file for ${stepName}:`, error);
+        logger.error(`Failed to load translation file for ${resolvedStepName}:`, error);
       }
     }
   }
 }
 
-export function getStepTranslations(req: Request, stepName: string): TranslationContent {
+/**
+ * Reads a step's translation bundle. `stepName` and `journeyFolder` are
+ * optional — when omitted they're read from `res.locals.step`.
+ */
+export function getStepTranslations(req: Request, stepName?: string, journeyFolder?: string): TranslationContent {
   if (!req.i18n) {
     return {};
   }
 
+  const resolvedStepName = resolveStepName(req, stepName);
+  if (!resolvedStepName) {
+    return {};
+  }
+
+  const resolvedFolder = resolveJourneyFolder(req, journeyFolder);
   const lang = getMainRequestLanguage(req);
-  const resources = req.i18n.getResourceBundle(lang, getStepNamespace(stepName));
+  const resources = req.i18n.getResourceBundle(lang, getStepNamespace(resolvedStepName, resolvedFolder));
   return (resources as TranslationContent) || {};
 }
 
-/** Gets the translation function for a request with step namespace support. */
-export function getTranslationFunction(req: Request, stepName?: string, namespaces: string[] = ['common']): TFunction {
+/**
+ * Translation function for a request. When `stepName` is omitted it's read
+ * from `res.locals.step`; the journey folder is always read from
+ * `res.locals.step` (which `withStepContext` populates per request).
+ */
+export function getTranslationFunction(
+  req: Request,
+  stepName?: string,
+  namespaces: string[] = ['common'],
+  journeyFolder?: string
+): TFunction {
   if (!req.i18n) {
     return getMainTranslationFunction(req, namespaces);
   }
 
+  const resolvedStepName = resolveStepName(req, stepName);
+  const resolvedFolder = resolveJourneyFolder(req, journeyFolder);
+
   const lang = getMainRequestLanguage(req);
-  const allNamespaces = stepName ? [getStepNamespace(stepName), ...namespaces] : namespaces;
+  const allNamespaces = resolvedStepName
+    ? [getStepNamespace(resolvedStepName, resolvedFolder), ...namespaces]
+    : namespaces;
   const fixedT = req.i18n.getFixedT(lang, allNamespaces);
   return fixedT || getMainTranslationFunction(req, namespaces);
 }

--- a/src/main/modules/steps/i18n.ts
+++ b/src/main/modules/steps/i18n.ts
@@ -76,27 +76,25 @@ function getStepTranslationPaths(req: Request, stepName: string, folder: string)
 }
 
 /**
- * Loads and registers a step's translations under a journey-scoped i18next
- * namespace. The early-return cache check is safe because the namespace is
- * unique per (journey, step), so the first request warms it and subsequent
- * requests skip the disk read.
+ * Loads and registers the current step's translations under a journey-scoped
+ * i18next namespace. The step is read from `res.locals.step` (set by
+ * `withStepContext` middleware); outside a step request the call is a no-op.
  *
- * `stepName` and `folder` are optional — when omitted they're read from
- * `res.locals.step` (set by `withStepContext` middleware in registerSteps).
+ * The resource-bundle cache check is safe because the namespace is unique per
+ * (journey, step), so the first request warms it and subsequent requests skip
+ * the disk read.
  */
-export async function loadStepNamespace(req: Request, stepName?: string, folder?: string): Promise<void> {
+export async function loadStepNamespace(req: Request): Promise<void> {
   if (!req.i18n) {
     return;
   }
 
-  const resolvedStepName = stepName ?? req.res?.locals.step?.name;
-  const resolvedFolder = folder ?? req.res?.locals.step?.journey;
-
-  if (!resolvedStepName || !resolvedFolder) {
+  const step = req.res?.locals.step;
+  if (!step) {
     return;
   }
 
-  const stepNamespace = getStepTranslationPath(resolvedStepName, resolvedFolder);
+  const stepNamespace = getStepTranslationPath(step.name, step.journey);
   const lang = getMainRequestLanguage(req);
 
   if (req.i18n.getResourceBundle(lang, stepNamespace)) {
@@ -106,7 +104,7 @@ export async function loadStepNamespace(req: Request, stepName?: string, folder?
   const localesDir = await findLocalesDir();
   if (!localesDir) {
     if (isDevelopment) {
-      logger.warn(`Locales directory not found. Translation file for ${resolvedStepName} will not be loaded.`);
+      logger.warn(`Locales directory not found. Translation file for ${step.name} will not be loaded.`);
     }
     return;
   }
@@ -114,7 +112,7 @@ export async function loadStepNamespace(req: Request, stepName?: string, folder?
   try {
     let translations: Record<string, unknown> = {};
 
-    for (const translationPath of getStepTranslationPaths(req, resolvedStepName, resolvedFolder)) {
+    for (const translationPath of getStepTranslationPaths(req, step.name, step.journey)) {
       const filePath = path.join(localesDir, lang, `${translationPath}.json`);
       const resolvedPath = path.resolve(filePath);
       const resolvedLocalesDir = path.resolve(localesDir);
@@ -151,55 +149,41 @@ export async function loadStepNamespace(req: Request, stepName?: string, folder?
     if (isDevelopment) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       if (!errorMessage.includes('ENOENT')) {
-        logger.error(`Failed to load translation file for ${resolvedStepName}:`, error);
+        logger.error(`Failed to load translation file for ${step.name}:`, error);
       }
     }
   }
 }
 
-/**
- * Reads a step's translation bundle. `stepName` and `journeyFolder` are
- * optional — when omitted they're read from `res.locals.step`.
- */
-export function getStepTranslations(req: Request, stepName?: string, journeyFolder?: string): TranslationContent {
+/** Reads the current step's translation bundle (empty when outside a step request). */
+export function getStepTranslations(req: Request): TranslationContent {
   if (!req.i18n) {
     return {};
   }
 
-  const resolvedStepName = stepName ?? req.res?.locals.step?.name;
-  const resolvedFolder = journeyFolder ?? req.res?.locals.step?.journey;
-  if (!resolvedStepName || !resolvedFolder) {
+  const step = req.res?.locals.step;
+  if (!step) {
     return {};
   }
 
   const lang = getMainRequestLanguage(req);
-  const resources = req.i18n.getResourceBundle(lang, getStepTranslationPath(resolvedStepName, resolvedFolder));
+  const resources = req.i18n.getResourceBundle(lang, getStepTranslationPath(step.name, step.journey));
   return (resources as TranslationContent) || {};
 }
 
 /**
- * Translation function for a request. When `stepName` is omitted it's read
- * from `res.locals.step`; the journey folder is always read from
- * `res.locals.step` (which `withStepContext` populates per request).
+ * Translation function for a request. When a step context is set on
+ * `res.locals.step` the step's namespace is prepended to `namespaces`;
+ * otherwise this falls back to the common-only main translation function.
  */
-export function getTranslationFunction(
-  req: Request,
-  stepName?: string,
-  namespaces: string[] = ['common'],
-  journeyFolder?: string
-): TFunction {
+export function getTranslationFunction(req: Request, namespaces: string[] = ['common']): TFunction {
   if (!req.i18n) {
     return getMainTranslationFunction(req, namespaces);
   }
 
-  const resolvedStepName = stepName ?? req.res?.locals.step?.name;
-  const resolvedFolder = journeyFolder ?? req.res?.locals.step?.journey;
-
+  const step = req.res?.locals.step;
   const lang = getMainRequestLanguage(req);
-  const allNamespaces =
-    resolvedStepName && resolvedFolder
-      ? [getStepTranslationPath(resolvedStepName, resolvedFolder), ...namespaces]
-      : namespaces;
+  const allNamespaces = step ? [getStepTranslationPath(step.name, step.journey), ...namespaces] : namespaces;
   const fixedT = req.i18n.getFixedT(lang, allNamespaces);
   return fixedT || getMainTranslationFunction(req, namespaces);
 }

--- a/src/main/modules/steps/index.ts
+++ b/src/main/modules/steps/index.ts
@@ -45,6 +45,10 @@ export {
   validateTranslationKey,
 } from './i18n';
 
+// Export step request-context helpers
+export { getStepContext, withStepContext } from './stepContext';
+export type { StepContext } from './stepContext';
+
 // Re-export language utilities from main i18n module for convenience
 export { getRequestLanguage, getValidatedLanguage } from '../i18n';
 export type { SupportedLang, TranslationContent } from './i18n';

--- a/src/main/modules/steps/index.ts
+++ b/src/main/modules/steps/index.ts
@@ -45,7 +45,7 @@ export {
 } from './i18n';
 
 // Export step request-context helpers
-export { getStepContext, withStepContext } from './stepContext';
+export { withStepContext } from './stepContext';
 export type { StepContext } from './stepContext';
 
 // Re-export language utilities from main i18n module for convenience

--- a/src/main/modules/steps/index.ts
+++ b/src/main/modules/steps/index.ts
@@ -37,7 +37,6 @@ export {
 
 // Export step-specific i18n utilities
 export {
-  getStepNamespace,
   getStepTranslationPath,
   loadStepNamespace,
   getStepTranslations,

--- a/src/main/modules/steps/stepContext.ts
+++ b/src/main/modules/steps/stepContext.ts
@@ -1,12 +1,8 @@
-import type { Request, RequestHandler } from 'express';
+import type { RequestHandler } from 'express';
 
 export interface StepContext {
   name: string;
   journey: string;
-}
-
-export function getStepContext(req: Request): StepContext | undefined {
-  return req.res?.locals.step;
 }
 
 export const withStepContext =

--- a/src/main/modules/steps/stepContext.ts
+++ b/src/main/modules/steps/stepContext.ts
@@ -1,0 +1,17 @@
+import type { Request, RequestHandler } from 'express';
+
+export interface StepContext {
+  name: string;
+  journey: string;
+}
+
+export function getStepContext(req: Request): StepContext | undefined {
+  return req.res?.locals.step;
+}
+
+export const withStepContext =
+  (ctx: StepContext): RequestHandler =>
+  (_req, res, next) => {
+    res.locals.step = ctx;
+    next();
+  };

--- a/src/main/routes/registerSteps.ts
+++ b/src/main/routes/registerSteps.ts
@@ -4,7 +4,7 @@ import type { RequestHandler } from 'express';
 import { caseReferenceParamMiddleware, legalRepresentativeHeaderMiddleware, oidcMiddleware } from '../middleware';
 
 import { Logger } from '@modules/logger';
-import { getValidatedLanguage, stepDependencyCheckMiddleware } from '@modules/steps';
+import { getValidatedLanguage, stepDependencyCheckMiddleware, withStepContext } from '@modules/steps';
 import type { JourneyFlowConfig } from '@modules/steps/stepFlow.interface';
 import type { StepDefinition } from '@modules/steps/stepFormData.interface';
 import { getFlowConfigForJourney, getStepForJourney, getStepsForJourney, journeyRegistry } from '@steps';
@@ -39,14 +39,15 @@ function getJourneysToRegister(specificJourney?: string): [string, (typeof journ
 function buildGetMiddleware(
   requiresAuth: boolean,
   flowConfig: JourneyFlowConfig | ((req: Request) => JourneyFlowConfig),
+  stepContext: RequestHandler,
   stepMiddleware?: RequestHandler[]
 ): RequestHandler[] {
   const authMiddlewares = requiresAuth ? [oidcMiddleware] : [];
   const dependencyCheck = stepDependencyCheckMiddleware(flowConfig);
 
   return stepMiddleware
-    ? [...authMiddlewares, dependencyCheck, ...stepMiddleware, legalRepresentativeHeaderMiddleware]
-    : [...authMiddlewares, dependencyCheck, legalRepresentativeHeaderMiddleware];
+    ? [stepContext, ...authMiddlewares, dependencyCheck, ...stepMiddleware, legalRepresentativeHeaderMiddleware]
+    : [stepContext, ...authMiddlewares, dependencyCheck, legalRepresentativeHeaderMiddleware];
 }
 
 /**
@@ -90,14 +91,15 @@ function registerStepRoutes(
   const stepConfig = flowConfig.steps[step.name];
   const requiresAuth = stepConfig?.requiresAuth !== false;
   const authMiddlewares = requiresAuth ? [oidcMiddleware] : [];
+  const stepContext = withStepContext({ name: step.name, journey: journeyName });
 
   if (step.getController) {
-    const allGetMiddleware = buildGetMiddleware(requiresAuth, flowConfigResolver, step.middleware);
+    const allGetMiddleware = buildGetMiddleware(requiresAuth, flowConfigResolver, stepContext, step.middleware);
     router.get(step.url, ...allGetMiddleware, createGetHandler(step, journeyName));
   }
 
   if (step.postController?.post) {
-    router.post(step.url, ...authMiddlewares, (req, res, next) => {
+    router.post(step.url, stepContext, ...authMiddlewares, (req, res, next) => {
       const resolvedStep = getStepForJourney(journeyName, step.name, req) || step;
       return resolvedStep.postController?.post ? resolvedStep.postController.post(req, res, next) : next();
     });

--- a/src/main/steps/case-tasks/upload-additional-documents/confirm-if-these-documents-relate-to-an-application/index.ts
+++ b/src/main/steps/case-tasks/upload-additional-documents/confirm-if-these-documents-relate-to-an-application/index.ts
@@ -20,13 +20,7 @@ export const step: StepDefinition = {
   view: templatePath,
   stepDir: __dirname,
   getController: () =>
-    createGetController(
-      templatePath,
-      stepName,
-      stepNavigation,
-      (req: Request) => ({
-        dashboardUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
-      }),
-      'uploadAdditionalDocuments'
-    ),
+    createGetController(templatePath, stepName, stepNavigation, (req: Request) => ({
+      dashboardUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
+    })),
 };

--- a/src/main/steps/case-tasks/upload-additional-documents/start-now/index.ts
+++ b/src/main/steps/case-tasks/upload-additional-documents/start-now/index.ts
@@ -19,17 +19,11 @@ export const step: StepDefinition = {
   view: templatePath,
   stepDir: __dirname,
   getController: () =>
-    createGetController(
-      templatePath,
-      stepName,
-      stepNavigation,
-      (req: Request) => ({
-        backUrl: getDashboardUrl(req.res?.locals.validatedCase?.id) ?? '/dashboard',
-        dashboardUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
-        url: req.originalUrl || '',
-      }),
-      journeyName
-    ),
+    createGetController(templatePath, stepName, stepNavigation, (req: Request) => ({
+      backUrl: getDashboardUrl(req.res?.locals.validatedCase?.id) ?? '/dashboard',
+      dashboardUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
+      url: req.originalUrl || '',
+    })),
   postController: {
     post: async (req: Request, res: Response) => {
       const redirectPath = await stepNavigation.getNextStepUrl(req, stepName);

--- a/src/main/steps/case-tasks/upload-additional-documents/upload-your-documents/index.ts
+++ b/src/main/steps/case-tasks/upload-additional-documents/upload-your-documents/index.ts
@@ -19,13 +19,7 @@ export const step: StepDefinition = {
   view: templatePath,
   stepDir: __dirname,
   getController: () =>
-    createGetController(
-      templatePath,
-      stepName,
-      stepNavigation,
-      (req: Request) => ({
-        dashboardUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
-      }),
-      'uploadAdditionalDocuments'
-    ),
+    createGetController(templatePath, stepName, stepNavigation, (req: Request) => ({
+      dashboardUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
+    })),
 };

--- a/src/main/steps/make-an-application/check-your-answers/index.ts
+++ b/src/main/steps/make-an-application/check-your-answers/index.ts
@@ -58,7 +58,7 @@ export const step: StepDefinition = createFormStep({
     understandProceedings: 'statementOfTruth.understandProceedings',
   },
   extendGetContent: async (req: Request) => {
-    const t: TFunction = getTranslationFunction(req, STEP_NAME, ['common']);
+    const t: TFunction = getTranslationFunction(req);
 
     const visibleFormData = new VisibleFormDataView(req);
 

--- a/src/main/steps/make-an-application/what-order-do-you-want-the-court-to-make-and-why/index.ts
+++ b/src/main/steps/make-an-application/what-order-do-you-want-the-court-to-make-and-why/index.ts
@@ -36,7 +36,7 @@ export const step: StepDefinition = createFormStep({
     const typeOfApplication = req.session.formData?.['choose-an-application']?.['typeOfApplication'] ?? '';
 
     let contentList: string[] = [];
-    const t = getTranslationFunction(req, STEP_NAME, ['common']);
+    const t = getTranslationFunction(req);
 
     if (typeOfApplication === 'ADJOURN' || typeOfApplication === 'SOMETHING_ELSE') {
       contentList = t(`list.${typeOfApplication}`, { returnObjects: true }) as unknown as string[];

--- a/src/main/steps/respond-to-claim/confirmation-of-notice-date-when-not-provided/index.ts
+++ b/src/main/steps/respond-to-claim/confirmation-of-notice-date-when-not-provided/index.ts
@@ -92,7 +92,7 @@ export const step: StepDefinition = createFormStep({
   extendGetContent: req => {
     const claimantName = getClaimantName(req);
 
-    const t = getTranslationFunction(req, 'confirmation-of-notice-date-when-not-provided', ['common']);
+    const t = getTranslationFunction(req);
 
     const paragraph = t('paragraph', { returnObjects: true, claimantName });
 

--- a/src/main/steps/respond-to-claim/confirmation-of-notice-date-when-provided/index.ts
+++ b/src/main/steps/respond-to-claim/confirmation-of-notice-date-when-provided/index.ts
@@ -105,7 +105,7 @@ export const step: StepDefinition = createFormStep({
       ? DateTime.fromISO(noticeDateRaw).setZone('Europe/London').setLocale('en-gb').toFormat('d LLLL y')
       : '';
 
-    const t = getTranslationFunction(req, 'confirmation-of-notice-date-when-provided', ['common']);
+    const t = getTranslationFunction(req);
 
     const bulletPointLabel = t('bulletPointLabel', { returnObjects: true, claimantName });
     const hintText = t('hintText', { returnObjects: true, claimantName });

--- a/src/main/steps/respond-to-claim/correspondence-address/index.ts
+++ b/src/main/steps/respond-to-claim/correspondence-address/index.ts
@@ -148,7 +148,7 @@ export const step: StepDefinition = createFormStep({
     return result;
   },
   extendGetContent: async (req, formContent) => {
-    const t = getTranslationFunction(req, 'correspondence-address', ['common']);
+    const t = getTranslationFunction(req);
     const possessionClaimResponse = req.res?.locals?.validatedCase?.possessionClaimResponse;
     const partyAddress = possessionClaimResponse?.defendantContactDetails?.party?.address;
     const { formattedAddress: formattedAddressStr } = getExistingAddress(req);

--- a/src/main/steps/respond-to-claim/current-circumstances/index.ts
+++ b/src/main/steps/respond-to-claim/current-circumstances/index.ts
@@ -49,7 +49,7 @@ export const step: StepDefinition = createFormStep({
   ],
   customTemplate: `${__dirname}/currentCircumstances.njk`,
   extendGetContent: req => {
-    const t = getTranslationFunction(req, 'your-circumstances', ['common']);
+    const t = getTranslationFunction(req);
 
     return {
       introParagraph: t('introParagraph'),

--- a/src/main/steps/respond-to-claim/dispute-claim-interstitial/index.ts
+++ b/src/main/steps/respond-to-claim/dispute-claim-interstitial/index.ts
@@ -22,7 +22,7 @@ export const step: StepDefinition = createFormStep({
   fields: [],
   extendGetContent: req => {
     const claimantName = getClaimantName(req);
-    const t = getTranslationFunction(req, 'dispute-claim-interstitial', ['common']);
+    const t = getTranslationFunction(req);
 
     return {
       heading: t('heading', { claimantName }),

--- a/src/main/steps/respond-to-claim/exceptional-hardship/index.ts
+++ b/src/main/steps/respond-to-claim/exceptional-hardship/index.ts
@@ -49,7 +49,7 @@ export const step: StepDefinition = createFormStep({
   ],
   customTemplate: `${__dirname}/exceptionalHardship.njk`,
   extendGetContent: req => {
-    const t = getTranslationFunction(req, 'exceptional-hardship', ['common']);
+    const t = getTranslationFunction(req);
 
     return {
       introParagraph1: t('introParagraph1'),

--- a/src/main/steps/respond-to-claim/installment-payments/index.ts
+++ b/src/main/steps/respond-to-claim/installment-payments/index.ts
@@ -77,7 +77,7 @@ export const step: StepDefinition = createFormStep({
   ],
   extendGetContent: req => {
     const claimantName = getClaimantName(req);
-    const t = getTranslationFunction(req, 'installment-payments', ['common']);
+    const t = getTranslationFunction(req);
 
     return {
       paragraph1: t('paragraph1', { claimantName }),

--- a/src/main/steps/respond-to-claim/non-rent-arrears-dispute/index.ts
+++ b/src/main/steps/respond-to-claim/non-rent-arrears-dispute/index.ts
@@ -80,7 +80,7 @@ export const step: StepDefinition = createFormStep({
     const caseReference = req.params.caseReference;
     const claimantName = caseData?.possessionClaimResponse?.claimantOrganisations?.[0]?.value as string | undefined;
 
-    const t = getTranslationFunction(req, 'non-rent-arrears-dispute', ['common']);
+    const t = getTranslationFunction(req);
 
     // Pre-translate content with interpolation (following rent-arrears pattern)
     return {

--- a/src/main/steps/respond-to-claim/payment-interstitial/index.ts
+++ b/src/main/steps/respond-to-claim/payment-interstitial/index.ts
@@ -23,7 +23,7 @@ export const step: StepDefinition = createFormStep({
   fields: [],
   extendGetContent: req => {
     const claimantName = getClaimantName(req);
-    const t = getTranslationFunction(req, 'payment-interstitial', ['common']);
+    const t = getTranslationFunction(req);
 
     return {
       paragraph1: t('paragraph1', { claimantName }),

--- a/src/main/steps/respond-to-claim/rent-arrears-dispute/index.ts
+++ b/src/main/steps/respond-to-claim/rent-arrears-dispute/index.ts
@@ -72,7 +72,7 @@ export const step: StepDefinition = createFormStep({
     const amountInPounds = typeof amountInPence === 'string' ? parseFloat(amountInPence) / 100 : amountInPence / 100;
     const rentArrearsAmount = currency(amountInPounds);
 
-    const t = getTranslationFunction(req, 'rent-arrears-dispute', ['common']);
+    const t = getTranslationFunction(req);
 
     const insetIntroText = t('insetIntroText');
     const insetDetailsText = t('insetDetailsText', { claimantName });

--- a/src/main/steps/respond-to-claim/start-now/index.ts
+++ b/src/main/steps/respond-to-claim/start-now/index.ts
@@ -17,17 +17,11 @@ export const step: StepDefinition = {
   view: 'respond-to-claim/start-now/startNow.njk',
   stepDir: __dirname,
   getController: () => {
-    return createGetController(
-      'respond-to-claim/start-now/startNow.njk',
-      stepName,
-      stepNavigation,
-      (req: Request) => {
-        return {
-          backUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
-        };
-      },
-      'respondToClaim'
-    );
+    return createGetController('respond-to-claim/start-now/startNow.njk', stepName, stepNavigation, (req: Request) => {
+      return {
+        backUrl: getDashboardUrl(req.res?.locals.validatedCase?.id),
+      };
+    });
   },
   postController: {
     post: async (req: Request, res: Response) => {

--- a/src/main/steps/respond-to-claim/tenancy-date-details/index.ts
+++ b/src/main/steps/respond-to-claim/tenancy-date-details/index.ts
@@ -125,7 +125,7 @@ export const step: StepDefinition = createFormStep({
     // Format tenancy date with ordinal
     const tenancyStartDate = existingStartDate ? format(parseISO(existingStartDate), 'do LLLL yyyy') : undefined;
 
-    const t = getTranslationFunction(req, 'tenancy-date-details', ['common']);
+    const t = getTranslationFunction(req);
     const bulletPoint = t('bulletPoint', { returnObjects: true, tenancyStartDate });
     const subHeading = t('subHeading', { returnObjects: true, claimantName });
 

--- a/src/main/steps/respond-to-claim/tenancy-date-unknown/index.ts
+++ b/src/main/steps/respond-to-claim/tenancy-date-unknown/index.ts
@@ -84,7 +84,7 @@ export const step: StepDefinition = createFormStep({
     const claimantNameFromSession = req.session?.ccdCase?.data?.claimantName as string | undefined;
     const claimantName = claimantNameFromValidatedCase || claimantNameFromSession || 'Treetops Housing';
 
-    const t = getTranslationFunction(req, STEP_NAME, ['common']);
+    const t = getTranslationFunction(req);
     const paragraph = t('paragraph', { claimantName });
 
     return {

--- a/src/main/steps/respond-to-claim/tenancy-type-details/index.ts
+++ b/src/main/steps/respond-to-claim/tenancy-type-details/index.ts
@@ -151,7 +151,7 @@ export const step: StepDefinition = createFormStep({
         ? `${formContent.detailsHeading}${orgName}${':'}`
         : formContent.detailsHeading;
 
-    const t = getTranslationFunction(req, STEP_NAME, ['common']);
+    const t = getTranslationFunction(req);
     let tenancyType: unknown;
     if (walesProperty) {
       if (occupationLicenceTypeWales === 'OTHER') {

--- a/src/test/unit/app/controller/controllerFactory.test.ts
+++ b/src/test/unit/app/controller/controllerFactory.test.ts
@@ -26,7 +26,6 @@ jest.mock('@modules/steps/i18n', () => ({
   getValidatedLanguage: jest.fn(() => 'en'),
   getRequestLanguage: (...args: unknown[]) => mockGetRequestLanguage(...args),
   getTranslationFunction: (...args: unknown[]) => mockGetTranslationFunction(...args),
-  getStepNamespace: jest.fn((stepName: string) => stepName),
   getStepTranslations: jest.fn(() => ({})),
   loadStepNamespace: jest.fn(),
 }));

--- a/src/test/unit/app/utils/formBuilder.test.ts
+++ b/src/test/unit/app/utils/formBuilder.test.ts
@@ -52,7 +52,6 @@ jest.mock('@modules/steps/i18n', () => ({
   getValidatedLanguage: (...args: unknown[]) => mockGetValidatedLanguage(...args),
   getRequestLanguage: (...args: unknown[]) => mockGetRequestLanguage(...args),
   getTranslationFunction: (...args: unknown[]) => mockGetTranslationFunction(...args),
-  getStepNamespace: jest.fn((stepName: string) => stepName),
   loadStepNamespace: jest.fn(),
   getStepTranslations: jest.fn(() => ({})),
 }));

--- a/src/test/unit/modules/steps/i18n.test.ts
+++ b/src/test/unit/modules/steps/i18n.test.ts
@@ -51,10 +51,18 @@ describe('steps/i18n', () => {
   });
 
   describe('getStepNamespace', () => {
-    it('should convert step name to namespace', () => {
+    it('should convert step name to namespace when no journey folder is provided', () => {
       expect(getStepNamespace('enter-dob')).toBe('enterDob');
       expect(getStepNamespace('respond-to-claim-summary')).toBe('respondToClaimSummary');
       expect(getStepNamespace('single-word')).toBe('singleWord');
+    });
+
+    it('should produce distinct namespaces for the same step in different journeys', () => {
+      expect(getStepNamespace('start-now', 'respondToClaim')).toBe('respondToClaim__startNow');
+      expect(getStepNamespace('start-now', 'uploadAdditionalDocuments')).toBe('uploadAdditionalDocuments__startNow');
+      expect(getStepNamespace('start-now', 'respondToClaim')).not.toBe(
+        getStepNamespace('start-now', 'uploadAdditionalDocuments')
+      );
     });
   });
 
@@ -72,30 +80,102 @@ describe('steps/i18n', () => {
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
-    it('should reload the bundle even when one is already loaded for the namespace', async () => {
-      // Different journeys can share a step name (e.g. "start-now"), which means
-      // they share an i18next namespace. We must not skip loading just because a
-      // bundle already exists, otherwise the previous journey's translations win.
-      const mockLocalesDir = '/test/locales';
-      const mockTranslations = { title: 'Reloaded Title' };
-      const loadNamespaces = jest.fn((_ns: string, cb: (err: unknown) => void) => cb(null));
-
-      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(mockLocalesDir);
+    it('should skip loading when a journey-scoped namespace bundle is already cached', async () => {
+      // Namespaces are now scoped by journey, so once a (journey, step) bundle
+      // is loaded the next request for the same pair short-circuits — no disk
+      // I/O, no shared mutable state, no race.
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
       const addResourceBundle = jest.fn();
-      // Simulate that a bundle for this namespace already exists (loaded by another journey).
-      const getResourceBundle = jest.fn().mockReturnValue({ stale: 'value' });
+      const getResourceBundle = jest.fn().mockReturnValue({ already: 'loaded' });
+      const access = jest.spyOn(fs, 'access');
+      const req = {
+        i18n: { getResourceBundle, addResourceBundle, loadNamespaces: jest.fn() },
+      } as any;
+
+      await loadStepNamespace(req, 'test-step', 'folder');
+
+      expect(getResourceBundle).toHaveBeenCalledWith('en', 'folder__testStep');
+      expect(access).not.toHaveBeenCalled();
+      expect(addResourceBundle).not.toHaveBeenCalled();
+    });
+
+    it('should isolate the same step name across journeys into distinct namespaces', async () => {
+      // Two journeys with a "start-now" step must NOT share a bundle —
+      // the bug the journey-scoped namespace fixes.
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const loadNamespaces = jest.fn((_ns: string, cb: (err: unknown) => void) => cb(null));
+      const addResourceBundle = jest.fn();
+      const getResourceBundle = jest.fn().mockReturnValue(null);
       const req = {
         i18n: { getResourceBundle, addResourceBundle, loadNamespaces },
       } as any;
 
       jest.spyOn(fs, 'access').mockResolvedValue(undefined);
-      jest.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify(mockTranslations));
+      jest
+        .spyOn(fs, 'readFile')
+        .mockResolvedValueOnce(JSON.stringify({ title: 'Journey A' }))
+        .mockResolvedValueOnce(JSON.stringify({ title: 'Journey B' }));
 
-      await loadStepNamespace(req, 'test-step', 'folder');
+      await loadStepNamespace(req, 'start-now', 'journeyA');
+      await loadStepNamespace(req, 'start-now', 'journeyB');
 
-      expect(addResourceBundle).toHaveBeenCalledWith('en', 'testStep', mockTranslations, true, true);
+      expect(addResourceBundle).toHaveBeenNthCalledWith(
+        1,
+        'en',
+        'journeyA__startNow',
+        { title: 'Journey A' },
+        true,
+        true
+      );
+      expect(addResourceBundle).toHaveBeenNthCalledWith(
+        2,
+        'en',
+        'journeyB__startNow',
+        { title: 'Journey B' },
+        true,
+        true
+      );
+    });
+
+    it('should derive step name and journey from res.locals.step when args are omitted', async () => {
+      // withStepContext middleware sets res.locals.step on every step request
+      // so callers can use the helpers without threading stepName/journey through.
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const loadNamespaces = jest.fn((_ns: string, cb: (err: unknown) => void) => cb(null));
+      const addResourceBundle = jest.fn();
+      const getResourceBundle = jest.fn().mockReturnValue(null);
+      const req = {
+        i18n: { getResourceBundle, addResourceBundle, loadNamespaces },
+        res: { locals: { step: { name: 'start-now', journey: 'uploadAdditionalDocuments' } } },
+      } as any;
+
+      jest.spyOn(fs, 'access').mockResolvedValue(undefined);
+      jest.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify({ title: 'From context' }));
+
+      await loadStepNamespace(req);
+
+      expect(addResourceBundle).toHaveBeenCalledWith(
+        'en',
+        'uploadAdditionalDocuments__startNow',
+        { title: 'From context' },
+        true,
+        true
+      );
+    });
+
+    it('should return without loading when no step name or journey is resolvable', async () => {
+      const req = { i18n: { getResourceBundle: jest.fn() } } as any;
+      const access = jest.spyOn(fs, 'access');
+
+      await loadStepNamespace(req);
+
+      expect(access).not.toHaveBeenCalled();
     });
 
     it('should return early if locales directory not found', async () => {
@@ -138,8 +218,8 @@ describe('steps/i18n', () => {
 
       await loadStepNamespace(req, 'test-step', 'testFolder');
 
-      expect(addResourceBundle).toHaveBeenCalledWith('en', 'testStep', mockTranslations, true, true);
-      expect(loadNamespaces).toHaveBeenCalledWith('testStep', expect.any(Function));
+      expect(addResourceBundle).toHaveBeenCalledWith('en', 'testFolder__testStep', mockTranslations, true, true);
+      expect(loadNamespaces).toHaveBeenCalledWith('testFolder__testStep', expect.any(Function));
     });
 
     it('should merge legalrep translations over default translations', async () => {
@@ -170,7 +250,7 @@ describe('steps/i18n', () => {
 
       expect(addResourceBundle).toHaveBeenCalledWith(
         'en',
-        'testStep',
+        'testFolder__testStep',
         {
           title: 'Professional title',
           nested: {
@@ -302,6 +382,22 @@ describe('steps/i18n', () => {
 
       expect(result).toEqual({});
     });
+
+    it('should read the journey-scoped namespace when journey context is set', () => {
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const bundle = { title: 'Hello' };
+      const getResourceBundle = jest.fn().mockReturnValue(bundle);
+      const req = {
+        i18n: { getResourceBundle },
+        res: { locals: { step: { name: 'start-now', journey: 'uploadAdditionalDocuments' } } },
+      } as any;
+
+      const result = getStepTranslations(req);
+
+      expect(getResourceBundle).toHaveBeenCalledWith('en', 'uploadAdditionalDocuments__startNow');
+      expect(result).toBe(bundle);
+    });
   });
 
   describe('getTranslationFunction', () => {
@@ -345,6 +441,37 @@ describe('steps/i18n', () => {
 
       expect(mainI18n.getTranslationFunction).toHaveBeenCalledWith(req, ['common']);
       expect(result).toBe(mockT);
+    });
+
+    it('should use the journey-scoped namespace when context is set on res.locals', () => {
+      const mockFixedT = jest.fn();
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const getFixedT = jest.fn().mockReturnValue(mockFixedT);
+      const req = {
+        i18n: { getFixedT },
+        res: { locals: { step: { name: 'start-now', journey: 'uploadAdditionalDocuments' } } },
+      } as any;
+
+      const result = getTranslationFunction(req);
+
+      expect(getFixedT).toHaveBeenCalledWith('en', ['uploadAdditionalDocuments__startNow', 'common']);
+      expect(result).toBe(mockFixedT);
+    });
+
+    it('should prefer explicit args over res.locals step context', () => {
+      const mockFixedT = jest.fn();
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const getFixedT = jest.fn().mockReturnValue(mockFixedT);
+      const req = {
+        i18n: { getFixedT },
+        res: { locals: { step: { name: 'start-now', journey: 'journeyA' } } },
+      } as any;
+
+      getTranslationFunction(req, 'other-step', ['common'], 'journeyB');
+
+      expect(getFixedT).toHaveBeenCalledWith('en', ['journeyB__otherStep', 'common']);
     });
   });
 

--- a/src/test/unit/modules/steps/i18n.test.ts
+++ b/src/test/unit/modules/steps/i18n.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { promises as fs } from 'fs';
 import path from 'path';
 
@@ -34,6 +33,20 @@ jest.mock('../../../../main/steps/utils', () => ({
   getUserType: (...args: unknown[]) => mockGetUserType(...args),
 }));
 
+interface ReqOverrides {
+  i18n?: Record<string, unknown>;
+  step?: { name: string; journey: string };
+}
+
+function buildReq({ i18n, step }: ReqOverrides = {}): Request {
+  return {
+    ...(i18n !== undefined ? { i18n } : {}),
+    res: step ? { locals: { step } } : { locals: {} },
+  } as unknown as Request;
+}
+
+const stepContext = { name: 'test-step', journey: 'testFolder' };
+
 describe('steps/i18n', () => {
   const originalEnv = process.env.NODE_ENV;
 
@@ -67,13 +80,18 @@ describe('steps/i18n', () => {
 
   describe('loadStepNamespace', () => {
     it('should return early if req.i18n is missing', async () => {
-      const req = {} as Request;
-      await loadStepNamespace(req, 'test-step', 'folder');
+      await loadStepNamespace(buildReq({ step: stepContext }));
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
+    it('should return without loading when res.locals.step is not set', async () => {
+      const access = jest.spyOn(fs, 'access');
+      await loadStepNamespace(buildReq({ i18n: { getResourceBundle: jest.fn() } }));
+      expect(access).not.toHaveBeenCalled();
+    });
+
     it('should skip loading when a journey-scoped namespace bundle is already cached', async () => {
-      // Namespaces are now scoped by journey, so once a (journey, step) bundle
+      // Namespaces are scoped by journey, so once a (journey, step) bundle
       // is loaded the next request for the same pair short-circuits — no disk
       // I/O, no shared mutable state, no race.
       (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
@@ -82,11 +100,12 @@ describe('steps/i18n', () => {
       const addResourceBundle = jest.fn();
       const getResourceBundle = jest.fn().mockReturnValue({ already: 'loaded' });
       const access = jest.spyOn(fs, 'access');
-      const req = {
+      const req = buildReq({
         i18n: { getResourceBundle, addResourceBundle, loadNamespaces: jest.fn() },
-      } as any;
+        step: { name: 'test-step', journey: 'folder' },
+      });
 
-      await loadStepNamespace(req, 'test-step', 'folder');
+      await loadStepNamespace(req);
 
       expect(getResourceBundle).toHaveBeenCalledWith('en', 'folder/testStep');
       expect(access).not.toHaveBeenCalled();
@@ -102,9 +121,7 @@ describe('steps/i18n', () => {
       const loadNamespaces = jest.fn((_ns: string, cb: (err: unknown) => void) => cb(null));
       const addResourceBundle = jest.fn();
       const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle, addResourceBundle, loadNamespaces },
-      } as any;
+      const i18n = { getResourceBundle, addResourceBundle, loadNamespaces };
 
       jest.spyOn(fs, 'access').mockResolvedValue(undefined);
       jest
@@ -112,8 +129,8 @@ describe('steps/i18n', () => {
         .mockResolvedValueOnce(JSON.stringify({ title: 'Journey A' }))
         .mockResolvedValueOnce(JSON.stringify({ title: 'Journey B' }));
 
-      await loadStepNamespace(req, 'start-now', 'journeyA');
-      await loadStepNamespace(req, 'start-now', 'journeyB');
+      await loadStepNamespace(buildReq({ i18n, step: { name: 'start-now', journey: 'journeyA' } }));
+      await loadStepNamespace(buildReq({ i18n, step: { name: 'start-now', journey: 'journeyB' } }));
 
       expect(addResourceBundle).toHaveBeenNthCalledWith(
         1,
@@ -133,54 +150,14 @@ describe('steps/i18n', () => {
       );
     });
 
-    it('should derive step name and journey from res.locals.step when args are omitted', async () => {
-      // withStepContext middleware sets res.locals.step on every step request
-      // so callers can use the helpers without threading stepName/journey through.
-      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
-      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
-
-      const loadNamespaces = jest.fn((_ns: string, cb: (err: unknown) => void) => cb(null));
-      const addResourceBundle = jest.fn();
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle, addResourceBundle, loadNamespaces },
-        res: { locals: { step: { name: 'start-now', journey: 'uploadAdditionalDocuments' } } },
-      } as any;
-
-      jest.spyOn(fs, 'access').mockResolvedValue(undefined);
-      jest.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify({ title: 'From context' }));
-
-      await loadStepNamespace(req);
-
-      expect(addResourceBundle).toHaveBeenCalledWith(
-        'en',
-        'uploadAdditionalDocuments/startNow',
-        { title: 'From context' },
-        true,
-        true
-      );
-    });
-
-    it('should return without loading when no step name or journey is resolvable', async () => {
-      const req = { i18n: { getResourceBundle: jest.fn() } } as any;
-      const access = jest.spyOn(fs, 'access');
-
-      await loadStepNamespace(req);
-
-      expect(access).not.toHaveBeenCalled();
-    });
-
     it('should return early if locales directory not found', async () => {
       process.env.NODE_ENV = 'development';
       (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(null);
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
+      const req = buildReq({ i18n: { getResourceBundle: jest.fn().mockReturnValue(null) }, step: stepContext });
 
-      await loadStepNamespace(req, 'test-step', 'folder');
+      await loadStepNamespace(req);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'Locales directory not found. Translation file for test-step will not be loaded.'
@@ -188,49 +165,39 @@ describe('steps/i18n', () => {
     });
 
     it('should load translation file successfully', async () => {
-      const mockLocalesDir = '/test/locales';
       const mockTranslations = { title: 'Test Title' };
       const loadNamespaces = jest.fn((_ns: string, cb: (err: unknown) => void) => cb(null));
 
-      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(mockLocalesDir);
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
       const addResourceBundle = jest.fn();
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: {
-          getResourceBundle,
-          addResourceBundle,
-          loadNamespaces,
-        },
-      } as any;
+      const req = buildReq({
+        i18n: { getResourceBundle: jest.fn().mockReturnValue(null), addResourceBundle, loadNamespaces },
+        step: stepContext,
+      });
 
       jest.spyOn(fs, 'access').mockResolvedValue(undefined);
       jest.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify(mockTranslations));
 
-      await loadStepNamespace(req, 'test-step', 'testFolder');
+      await loadStepNamespace(req);
 
       expect(addResourceBundle).toHaveBeenCalledWith('en', 'testFolder/testStep', mockTranslations, true, true);
       expect(loadNamespaces).toHaveBeenCalledWith('testFolder/testStep', expect.any(Function));
     });
 
     it('should merge legalrep translations over default translations', async () => {
-      const mockLocalesDir = '/test/locales';
       const loadNamespaces = jest.fn((_ns: string, cb: (err: unknown) => void) => cb(null));
 
-      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(mockLocalesDir);
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
       mockGetUserType.mockReturnValue('legalrep');
 
       const addResourceBundle = jest.fn();
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: {
-          getResourceBundle,
-          addResourceBundle,
-          loadNamespaces,
-        },
-      } as any;
+      const req = buildReq({
+        i18n: { getResourceBundle: jest.fn().mockReturnValue(null), addResourceBundle, loadNamespaces },
+        step: stepContext,
+      });
 
       jest.spyOn(fs, 'access').mockResolvedValue(undefined);
       jest
@@ -238,7 +205,7 @@ describe('steps/i18n', () => {
         .mockResolvedValueOnce(JSON.stringify({ title: 'Citizen title', nested: { keep: 'citizen', swap: 'base' } }))
         .mockResolvedValueOnce(JSON.stringify({ title: 'Professional title', nested: { swap: 'professional' } }));
 
-      await loadStepNamespace(req, 'test-step', 'testFolder');
+      await loadStepNamespace(req);
 
       expect(addResourceBundle).toHaveBeenCalledWith(
         'en',
@@ -261,12 +228,11 @@ describe('steps/i18n', () => {
       (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(mockLocalesDir);
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
+      const req = buildReq({
+        i18n: { getResourceBundle: jest.fn().mockReturnValue(null) },
+        step: { name: '../../../etc/passwd', journey: 'folder' },
+      });
 
-      // Mock path.resolve to simulate path traversal
       const originalResolve = path.resolve;
       jest.spyOn(path, 'resolve').mockImplementation((...args: string[]) => {
         if (args.some(arg => arg.includes('..'))) {
@@ -275,7 +241,7 @@ describe('steps/i18n', () => {
         return originalResolve(...args);
       });
 
-      await loadStepNamespace(req, '../../../etc/passwd', 'folder');
+      await loadStepNamespace(req);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Invalid translation path detected'));
 
@@ -284,19 +250,14 @@ describe('steps/i18n', () => {
 
     it('should handle file not found error silently', async () => {
       process.env.NODE_ENV = 'development';
-      const mockLocalesDir = '/test/locales';
-      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(mockLocalesDir);
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
+      const req = buildReq({ i18n: { getResourceBundle: jest.fn().mockReturnValue(null) }, step: stepContext });
 
-      const error = new Error('ENOENT: no such file');
-      jest.spyOn(fs, 'access').mockRejectedValue(error);
+      jest.spyOn(fs, 'access').mockRejectedValue(new Error('ENOENT: no such file'));
 
-      await loadStepNamespace(req, 'test-step', 'folder');
+      await loadStepNamespace(req);
 
       // File not found errors should be handled silently (no warning)
       expect(mockLogger.warn).not.toHaveBeenCalled();
@@ -305,58 +266,53 @@ describe('steps/i18n', () => {
 
     it('should handle other errors', async () => {
       process.env.NODE_ENV = 'development';
-      const mockLocalesDir = '/test/locales';
-      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(mockLocalesDir);
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
+      const req = buildReq({ i18n: { getResourceBundle: jest.fn().mockReturnValue(null) }, step: stepContext });
 
       const error = new Error('Parse error');
       jest.spyOn(fs, 'access').mockResolvedValue(undefined);
       jest.spyOn(fs, 'readFile').mockRejectedValue(error);
 
-      await loadStepNamespace(req, 'test-step', 'folder');
+      await loadStepNamespace(req);
 
       expect(mockLogger.error).toHaveBeenCalledWith('Failed to load translation file for test-step:', error);
     });
 
     it('should handle errors silently when not in development', async () => {
-      const mockLocalesDir = '/test/locales';
-      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue(mockLocalesDir);
+      (mainI18n.findLocalesDir as jest.Mock).mockResolvedValue('/test/locales');
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
+      const req = buildReq({ i18n: { getResourceBundle: jest.fn().mockReturnValue(null) }, step: stepContext });
 
-      const error = new Error('ENOENT: no such file');
-      jest.spyOn(fs, 'access').mockRejectedValue(error);
+      jest.spyOn(fs, 'access').mockRejectedValue(new Error('ENOENT: no such file'));
 
-      await expect(loadStepNamespace(req, 'test-step', 'folder')).resolves.not.toThrow();
+      await expect(loadStepNamespace(req)).resolves.not.toThrow();
     });
   });
 
   describe('getStepTranslations', () => {
     it('should return empty object if req.i18n is missing', () => {
-      const req = {} as Request;
-      const result = getStepTranslations(req, 'test-step');
+      expect(getStepTranslations(buildReq({ step: stepContext }))).toEqual({});
+    });
+
+    it('should return empty object when no step context is set', () => {
+      const getResourceBundle = jest.fn();
+      const result = getStepTranslations(buildReq({ i18n: { getResourceBundle } }));
+
+      expect(getResourceBundle).not.toHaveBeenCalled();
       expect(result).toEqual({});
     });
 
-    it('should return translations from resource bundle', () => {
+    it('should return translations from the journey-scoped resource bundle', () => {
       const mockTranslations = { title: 'Test Title', description: 'Test Description' };
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
       const getResourceBundle = jest.fn().mockReturnValue(mockTranslations);
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
+      const req = buildReq({ i18n: { getResourceBundle }, step: stepContext });
 
-      const result = getStepTranslations(req, 'test-step', 'testFolder');
+      const result = getStepTranslations(req);
 
       expect(getResourceBundle).toHaveBeenCalledWith('en', 'testFolder/testStep');
       expect(result).toEqual(mockTranslations);
@@ -365,42 +321,9 @@ describe('steps/i18n', () => {
     it('should return empty object if resource bundle is missing', () => {
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
-      const getResourceBundle = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
+      const req = buildReq({ i18n: { getResourceBundle: jest.fn().mockReturnValue(null) }, step: stepContext });
 
-      const result = getStepTranslations(req, 'test-step', 'testFolder');
-
-      expect(result).toEqual({});
-    });
-
-    it('should return empty object when no journey context is available', () => {
-      const getResourceBundle = jest.fn();
-      const req = {
-        i18n: { getResourceBundle },
-      } as any;
-
-      const result = getStepTranslations(req, 'test-step');
-
-      expect(getResourceBundle).not.toHaveBeenCalled();
-      expect(result).toEqual({});
-    });
-
-    it('should read the journey-scoped namespace when journey context is set', () => {
-      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
-
-      const bundle = { title: 'Hello' };
-      const getResourceBundle = jest.fn().mockReturnValue(bundle);
-      const req = {
-        i18n: { getResourceBundle },
-        res: { locals: { step: { name: 'start-now', journey: 'uploadAdditionalDocuments' } } },
-      } as any;
-
-      const result = getStepTranslations(req);
-
-      expect(getResourceBundle).toHaveBeenCalledWith('en', 'uploadAdditionalDocuments/startNow');
-      expect(result).toBe(bundle);
+      expect(getStepTranslations(req)).toEqual({});
     });
   });
 
@@ -409,26 +332,48 @@ describe('steps/i18n', () => {
       const mockT = jest.fn();
       (mainI18n.getTranslationFunction as jest.Mock).mockReturnValue(mockT);
 
-      const req = {} as Request;
+      const req = buildReq({ step: stepContext });
       const result = getTranslationFunction(req);
 
       expect(mainI18n.getTranslationFunction).toHaveBeenCalledWith(req, ['common']);
       expect(result).toBe(mockT);
     });
 
-    it('should return fixedT with step namespace when stepName and journey provided', () => {
+    it('should use the journey-scoped namespace when context is set', () => {
       const mockFixedT = jest.fn();
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
       const getFixedT = jest.fn().mockReturnValue(mockFixedT);
-      const req = {
+      const req = buildReq({
         i18n: { getFixedT },
-      } as any;
+        step: { name: 'start-now', journey: 'uploadAdditionalDocuments' },
+      });
 
-      const result = getTranslationFunction(req, 'test-step', ['common'], 'testFolder');
+      const result = getTranslationFunction(req);
 
-      expect(getFixedT).toHaveBeenCalledWith('en', ['testFolder/testStep', 'common']);
+      expect(getFixedT).toHaveBeenCalledWith('en', ['uploadAdditionalDocuments/startNow', 'common']);
       expect(result).toBe(mockFixedT);
+    });
+
+    it('should fall through to the common-only namespaces when no step context is set', () => {
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const getFixedT = jest.fn().mockReturnValue(jest.fn());
+      getTranslationFunction(buildReq({ i18n: { getFixedT } }));
+
+      expect(getFixedT).toHaveBeenCalledWith('en', ['common']);
+    });
+
+    it('should pass through additional namespaces alongside the step namespace', () => {
+      const mockFixedT = jest.fn();
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const getFixedT = jest.fn().mockReturnValue(mockFixedT);
+      const req = buildReq({ i18n: { getFixedT }, step: stepContext });
+
+      getTranslationFunction(req, ['common', 'dashboard']);
+
+      expect(getFixedT).toHaveBeenCalledWith('en', ['testFolder/testStep', 'common', 'dashboard']);
     });
 
     it('should fallback to main translation function if fixedT is null', () => {
@@ -437,59 +382,12 @@ describe('steps/i18n', () => {
       (mainI18n.getTranslationFunction as jest.Mock).mockReturnValue(mockT);
 
       const getFixedT = jest.fn().mockReturnValue(null);
-      const req = {
-        i18n: { getFixedT },
-      } as any;
-
-      const result = getTranslationFunction(req, 'test-step', ['common'], 'testFolder');
-
-      expect(mainI18n.getTranslationFunction).toHaveBeenCalledWith(req, ['common']);
-      expect(result).toBe(mockT);
-    });
-
-    it('should fall through to the common namespaces when no journey context is available', () => {
-      const mockFixedT = jest.fn();
-      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
-
-      const getFixedT = jest.fn().mockReturnValue(mockFixedT);
-      const req = {
-        i18n: { getFixedT },
-      } as any;
-
-      getTranslationFunction(req, 'test-step');
-
-      expect(getFixedT).toHaveBeenCalledWith('en', ['common']);
-    });
-
-    it('should use the journey-scoped namespace when context is set on res.locals', () => {
-      const mockFixedT = jest.fn();
-      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
-
-      const getFixedT = jest.fn().mockReturnValue(mockFixedT);
-      const req = {
-        i18n: { getFixedT },
-        res: { locals: { step: { name: 'start-now', journey: 'uploadAdditionalDocuments' } } },
-      } as any;
+      const req = buildReq({ i18n: { getFixedT }, step: stepContext });
 
       const result = getTranslationFunction(req);
 
-      expect(getFixedT).toHaveBeenCalledWith('en', ['uploadAdditionalDocuments/startNow', 'common']);
-      expect(result).toBe(mockFixedT);
-    });
-
-    it('should prefer explicit args over res.locals step context', () => {
-      const mockFixedT = jest.fn();
-      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
-
-      const getFixedT = jest.fn().mockReturnValue(mockFixedT);
-      const req = {
-        i18n: { getFixedT },
-        res: { locals: { step: { name: 'start-now', journey: 'journeyA' } } },
-      } as any;
-
-      getTranslationFunction(req, 'other-step', ['common'], 'journeyB');
-
-      expect(getFixedT).toHaveBeenCalledWith('en', ['journeyB/otherStep', 'common']);
+      expect(mainI18n.getTranslationFunction).toHaveBeenCalledWith(req, ['common']);
+      expect(result).toBe(mockT);
     });
   });
 
@@ -528,9 +426,7 @@ describe('steps/i18n', () => {
 
       validateTranslationKey(mockT, 'missing.key', 'test context');
 
-      // Note: This test depends on NODE_ENV at module load time
-      // If running in production, logger.warn won't be called
-      // If running in development/test, logger.warn will be called
+      // Depends on NODE_ENV at module load time
       expect(mockT).toHaveBeenCalledWith('missing.key');
     });
 

--- a/src/test/unit/modules/steps/i18n.test.ts
+++ b/src/test/unit/modules/steps/i18n.test.ts
@@ -15,7 +15,6 @@ jest.mock('@modules/logger', () => ({
 
 import * as mainI18n from '@modules/i18n';
 import {
-  getStepNamespace,
   getStepTranslationPath,
   getStepTranslations,
   getTranslationFunction,
@@ -50,26 +49,19 @@ describe('steps/i18n', () => {
     process.env.NODE_ENV = originalEnv;
   });
 
-  describe('getStepNamespace', () => {
-    it('should convert step name to namespace when no journey folder is provided', () => {
-      expect(getStepNamespace('enter-dob')).toBe('enterDob');
-      expect(getStepNamespace('respond-to-claim-summary')).toBe('respondToClaimSummary');
-      expect(getStepNamespace('single-word')).toBe('singleWord');
-    });
-
-    it('should produce distinct namespaces for the same step in different journeys', () => {
-      expect(getStepNamespace('start-now', 'respondToClaim')).toBe('respondToClaim__startNow');
-      expect(getStepNamespace('start-now', 'uploadAdditionalDocuments')).toBe('uploadAdditionalDocuments__startNow');
-      expect(getStepNamespace('start-now', 'respondToClaim')).not.toBe(
-        getStepNamespace('start-now', 'uploadAdditionalDocuments')
-      );
-    });
-  });
-
   describe('getStepTranslationPath', () => {
     it('should return correct translation path', () => {
       expect(getStepTranslationPath('start-now', 'respondToClaim')).toBe('respondToClaim/startNow');
       expect(getStepTranslationPath('summary', 'common')).toBe('common/summary');
+      expect(getStepTranslationPath('respond-to-claim-summary', 'respondToClaim')).toBe(
+        'respondToClaim/respondToClaimSummary'
+      );
+    });
+
+    it('should produce distinct identifiers for the same step in different journeys', () => {
+      expect(getStepTranslationPath('start-now', 'respondToClaim')).not.toBe(
+        getStepTranslationPath('start-now', 'uploadAdditionalDocuments')
+      );
     });
   });
 
@@ -96,7 +88,7 @@ describe('steps/i18n', () => {
 
       await loadStepNamespace(req, 'test-step', 'folder');
 
-      expect(getResourceBundle).toHaveBeenCalledWith('en', 'folder__testStep');
+      expect(getResourceBundle).toHaveBeenCalledWith('en', 'folder/testStep');
       expect(access).not.toHaveBeenCalled();
       expect(addResourceBundle).not.toHaveBeenCalled();
     });
@@ -126,7 +118,7 @@ describe('steps/i18n', () => {
       expect(addResourceBundle).toHaveBeenNthCalledWith(
         1,
         'en',
-        'journeyA__startNow',
+        'journeyA/startNow',
         { title: 'Journey A' },
         true,
         true
@@ -134,7 +126,7 @@ describe('steps/i18n', () => {
       expect(addResourceBundle).toHaveBeenNthCalledWith(
         2,
         'en',
-        'journeyB__startNow',
+        'journeyB/startNow',
         { title: 'Journey B' },
         true,
         true
@@ -162,7 +154,7 @@ describe('steps/i18n', () => {
 
       expect(addResourceBundle).toHaveBeenCalledWith(
         'en',
-        'uploadAdditionalDocuments__startNow',
+        'uploadAdditionalDocuments/startNow',
         { title: 'From context' },
         true,
         true
@@ -218,8 +210,8 @@ describe('steps/i18n', () => {
 
       await loadStepNamespace(req, 'test-step', 'testFolder');
 
-      expect(addResourceBundle).toHaveBeenCalledWith('en', 'testFolder__testStep', mockTranslations, true, true);
-      expect(loadNamespaces).toHaveBeenCalledWith('testFolder__testStep', expect.any(Function));
+      expect(addResourceBundle).toHaveBeenCalledWith('en', 'testFolder/testStep', mockTranslations, true, true);
+      expect(loadNamespaces).toHaveBeenCalledWith('testFolder/testStep', expect.any(Function));
     });
 
     it('should merge legalrep translations over default translations', async () => {
@@ -250,7 +242,7 @@ describe('steps/i18n', () => {
 
       expect(addResourceBundle).toHaveBeenCalledWith(
         'en',
-        'testFolder__testStep',
+        'testFolder/testStep',
         {
           title: 'Professional title',
           nested: {
@@ -364,9 +356,9 @@ describe('steps/i18n', () => {
         i18n: { getResourceBundle },
       } as any;
 
-      const result = getStepTranslations(req, 'test-step');
+      const result = getStepTranslations(req, 'test-step', 'testFolder');
 
-      expect(getResourceBundle).toHaveBeenCalledWith('en', 'testStep');
+      expect(getResourceBundle).toHaveBeenCalledWith('en', 'testFolder/testStep');
       expect(result).toEqual(mockTranslations);
     });
 
@@ -378,8 +370,20 @@ describe('steps/i18n', () => {
         i18n: { getResourceBundle },
       } as any;
 
+      const result = getStepTranslations(req, 'test-step', 'testFolder');
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when no journey context is available', () => {
+      const getResourceBundle = jest.fn();
+      const req = {
+        i18n: { getResourceBundle },
+      } as any;
+
       const result = getStepTranslations(req, 'test-step');
 
+      expect(getResourceBundle).not.toHaveBeenCalled();
       expect(result).toEqual({});
     });
 
@@ -395,7 +399,7 @@ describe('steps/i18n', () => {
 
       const result = getStepTranslations(req);
 
-      expect(getResourceBundle).toHaveBeenCalledWith('en', 'uploadAdditionalDocuments__startNow');
+      expect(getResourceBundle).toHaveBeenCalledWith('en', 'uploadAdditionalDocuments/startNow');
       expect(result).toBe(bundle);
     });
   });
@@ -412,7 +416,7 @@ describe('steps/i18n', () => {
       expect(result).toBe(mockT);
     });
 
-    it('should return fixedT with step namespace when stepName provided', () => {
+    it('should return fixedT with step namespace when stepName and journey provided', () => {
       const mockFixedT = jest.fn();
       (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
 
@@ -421,9 +425,9 @@ describe('steps/i18n', () => {
         i18n: { getFixedT },
       } as any;
 
-      const result = getTranslationFunction(req, 'test-step');
+      const result = getTranslationFunction(req, 'test-step', ['common'], 'testFolder');
 
-      expect(getFixedT).toHaveBeenCalledWith('en', ['testStep', 'common']);
+      expect(getFixedT).toHaveBeenCalledWith('en', ['testFolder/testStep', 'common']);
       expect(result).toBe(mockFixedT);
     });
 
@@ -437,10 +441,24 @@ describe('steps/i18n', () => {
         i18n: { getFixedT },
       } as any;
 
-      const result = getTranslationFunction(req, 'test-step');
+      const result = getTranslationFunction(req, 'test-step', ['common'], 'testFolder');
 
       expect(mainI18n.getTranslationFunction).toHaveBeenCalledWith(req, ['common']);
       expect(result).toBe(mockT);
+    });
+
+    it('should fall through to the common namespaces when no journey context is available', () => {
+      const mockFixedT = jest.fn();
+      (mainI18n.getRequestLanguage as jest.Mock).mockReturnValue('en');
+
+      const getFixedT = jest.fn().mockReturnValue(mockFixedT);
+      const req = {
+        i18n: { getFixedT },
+      } as any;
+
+      getTranslationFunction(req, 'test-step');
+
+      expect(getFixedT).toHaveBeenCalledWith('en', ['common']);
     });
 
     it('should use the journey-scoped namespace when context is set on res.locals', () => {
@@ -455,7 +473,7 @@ describe('steps/i18n', () => {
 
       const result = getTranslationFunction(req);
 
-      expect(getFixedT).toHaveBeenCalledWith('en', ['uploadAdditionalDocuments__startNow', 'common']);
+      expect(getFixedT).toHaveBeenCalledWith('en', ['uploadAdditionalDocuments/startNow', 'common']);
       expect(result).toBe(mockFixedT);
     });
 
@@ -471,7 +489,7 @@ describe('steps/i18n', () => {
 
       getTranslationFunction(req, 'other-step', ['common'], 'journeyB');
 
-      expect(getFixedT).toHaveBeenCalledWith('en', ['journeyB__otherStep', 'common']);
+      expect(getFixedT).toHaveBeenCalledWith('en', ['journeyB/otherStep', 'common']);
     });
   });
 

--- a/src/test/unit/routes/registerSteps.test.ts
+++ b/src/test/unit/routes/registerSteps.test.ts
@@ -185,19 +185,23 @@ describe('registerSteps', () => {
     const protectedGetCall = mockGet.mock.calls.find(call => call[0] === '/steps/protected');
     expect(protectedGetCall).toBeDefined();
 
-    expect(protectedGetCall!).toHaveLength(5);
+    // [url, stepContext, oidc, dependencyCheck, legalRepHeaders, handler]
+    expect(protectedGetCall!).toHaveLength(6);
     expect(protectedGetCall![0]).toBe('/steps/protected');
-    expect(protectedGetCall![1]).toBe(oidcMiddleware);
-    expect(protectedGetCall![2]).toBe(mockStepDependencyCheck);
-    expect(protectedGetCall![3]).toBe(legalRepresentativeHeaderMiddleware);
-    expect(typeof protectedGetCall![4]).toBe('function');
+    expect(typeof protectedGetCall![1]).toBe('function');
+    expect(protectedGetCall![2]).toBe(oidcMiddleware);
+    expect(protectedGetCall![3]).toBe(mockStepDependencyCheck);
+    expect(protectedGetCall![4]).toBe(legalRepresentativeHeaderMiddleware);
+    expect(typeof protectedGetCall![5]).toBe('function');
 
     const protectedPostCall = mockPost.mock.calls.find(call => call[0] === '/steps/protected');
     expect(protectedPostCall).toBeDefined();
-    expect(protectedPostCall!).toHaveLength(3);
+    // [url, stepContext, oidc, handler]
+    expect(protectedPostCall!).toHaveLength(4);
     expect(protectedPostCall![0]).toBe('/steps/protected');
-    expect(protectedPostCall![1]).toBe(oidcMiddleware);
-    expect(typeof protectedPostCall![2]).toBe('function');
+    expect(typeof protectedPostCall![1]).toBe('function');
+    expect(protectedPostCall![2]).toBe(oidcMiddleware);
+    expect(typeof protectedPostCall![3]).toBe('function');
   });
 
   it('registers GET and POST without middlewares for unprotected steps', () => {
@@ -205,24 +209,29 @@ describe('registerSteps', () => {
 
     const unprotectedGetCall = mockGet.mock.calls.find(call => call[0] === '/steps/unprotected');
     expect(unprotectedGetCall).toBeDefined();
-    expect(unprotectedGetCall!).toHaveLength(4);
+    // [url, stepContext, dependencyCheck, legalRepHeaders, handler]
+    expect(unprotectedGetCall!).toHaveLength(5);
     expect(unprotectedGetCall![0]).toBe('/steps/unprotected');
-    expect(unprotectedGetCall![1]).toBe(mockStepDependencyCheck);
-    expect(unprotectedGetCall![2]).toBe(legalRepresentativeHeaderMiddleware);
-    expect(typeof unprotectedGetCall![3]).toBe('function');
+    expect(typeof unprotectedGetCall![1]).toBe('function');
+    expect(unprotectedGetCall![2]).toBe(mockStepDependencyCheck);
+    expect(unprotectedGetCall![3]).toBe(legalRepresentativeHeaderMiddleware);
+    expect(typeof unprotectedGetCall![4]).toBe('function');
 
     const unprotectedPostCall = mockPost.mock.calls.find(call => call[0] === '/steps/unprotected');
     expect(unprotectedPostCall).toBeDefined();
-    expect(unprotectedPostCall!).toHaveLength(2);
+    // [url, stepContext, handler]
+    expect(unprotectedPostCall!).toHaveLength(3);
     expect(unprotectedPostCall![0]).toBe('/steps/unprotected');
     expect(typeof unprotectedPostCall![1]).toBe('function');
+    expect(typeof unprotectedPostCall![2]).toBe('function');
   });
 
   it('delegates POST handlers to the resolved step definition', () => {
     registerSteps(app);
 
     const protectedPostCall = mockPost.mock.calls.find(call => call[0] === '/steps/protected');
-    const handler = protectedPostCall?.[2];
+    // [url, stepContext, oidc, handler] — the last entry is the route handler.
+    const handler = protectedPostCall?.[protectedPostCall.length - 1];
     const req = createMockRequest('/steps/protected');
     const res = createMockResponse();
     const next = jest.fn();
@@ -248,13 +257,15 @@ describe('registerSteps', () => {
     const stepWithMiddlewareCall = mockGet.mock.calls.find(call => call[0] === '/steps/with-middleware');
 
     expect(stepWithMiddlewareCall).toBeDefined();
-    expect(stepWithMiddlewareCall!).toHaveLength(6);
+    // [url, stepContext, oidc, dependencyCheck, customMiddleware, legalRepHeaders, handler]
+    expect(stepWithMiddlewareCall!).toHaveLength(7);
     expect(stepWithMiddlewareCall![0]).toBe('/steps/with-middleware');
-    expect(stepWithMiddlewareCall![1]).toBe(oidcMiddleware);
-    expect(stepWithMiddlewareCall![2]).toBe(mockStepDependencyCheck);
-    expect(stepWithMiddlewareCall![3]).toBe(mockStepsData.stepWithMiddleware.middleware![0]);
-    expect(stepWithMiddlewareCall![4]).toBe(legalRepresentativeHeaderMiddleware);
-    expect(typeof stepWithMiddlewareCall![5]).toBe('function');
+    expect(typeof stepWithMiddlewareCall![1]).toBe('function');
+    expect(stepWithMiddlewareCall![2]).toBe(oidcMiddleware);
+    expect(stepWithMiddlewareCall![3]).toBe(mockStepDependencyCheck);
+    expect(stepWithMiddlewareCall![4]).toBe(mockStepsData.stepWithMiddleware.middleware![0]);
+    expect(stepWithMiddlewareCall![5]).toBe(legalRepresentativeHeaderMiddleware);
+    expect(typeof stepWithMiddlewareCall![6]).toBe('function');
   });
 
   it('calls getValidatedLanguage for each GET route', () => {
@@ -291,6 +302,24 @@ describe('registerSteps', () => {
         'accept-language': 'en-GB',
       },
     });
+  });
+
+  it('sets res.locals.step with the step name and journey on every step request', () => {
+    registerSteps(app);
+
+    const protectedGetCall = mockGet.mock.calls.find(call => call[0] === '/steps/protected');
+    const stepContextMiddleware = protectedGetCall![1] as (
+      req: unknown,
+      res: { locals: Record<string, unknown> },
+      next: () => void
+    ) => void;
+    const res = { locals: {} as Record<string, unknown> };
+    const next = jest.fn();
+
+    stepContextMiddleware({}, res, next);
+
+    expect(res.locals.step).toEqual({ name: 'protected-step', journey: 'respondToClaim' });
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it('logs successful registration with counts', () => {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,6 +7,7 @@ import { S2S } from '../main/modules/s2s';
 import { OIDCModule } from '../main/modules/oidc';
 import { type TFunction } from 'i18next';
 import { type CcdCaseModel } from '@services/ccdCaseData.model';
+import { type StepContext } from '../main/modules/steps/stepContext';
 
 export interface UserInfoResponseWithToken extends UserInfoResponse {
   accessToken: string;
@@ -44,6 +45,7 @@ declare module 'express' {
       validatedCase?: CcdCaseModel;
       t?: TFunction;
       lang?: string;
+      step?: StepContext;
     } & Record<string, unknown>;
     csrfToken?: () => string;
   }


### PR DESCRIPTION
## Summary

Targets `HDPI-5548-additional-info-screen` (PR #1247). Replaces the `loadStepNamespace` early-return removal with a structural fix to the underlying namespace collision.

### The bug

`getStepNamespace(stepName)` hashes purely on the step name — so two journeys with a step called `start-now` (e.g. `respondToClaim` and the new `uploadAdditionalDocuments`) collapse onto the same i18next namespace `startNow`. First journey to load wins; the second's bundle is silently dropped because the cache check sees the namespace is already populated.

### What #1247 did

Removed the `getResourceBundle` early-return in `loadStepNamespace`, so every step request re-reads its translations from disk and overwrites the shared bundle. That:

- Pays a `findLocalesDir` + `fs.access` + `fs.readFile` cost on every step page load (twice for non-citizen users), where the previous code paid zero after warmup.
- Makes the global i18next bundle mutated per-request — under load, two concurrent requests for different journeys' `start-now` can interleave loads such that one request's render sees the other's strings.

### What this PR does

Scopes the namespace by journey: `${journeyFolder}__${stepName}` (e.g. `respondToClaim__startNow` vs `uploadAdditionalDocuments__startNow`). Two journeys with the same step name no longer share a bundle, and the resource-bundle cache short-circuit comes back without risk.

- New `stepContext` module + `withStepContext({ name, journey })` middleware wired into every step's GET/POST in `registerSteps`. Sets `res.locals.step` before the controller runs.
- `getStepNamespace`, `getStepTranslations`, `getTranslationFunction`, and `loadStepNamespace` accept optional explicit args; when omitted they fall back to `res.locals.step`. Filesystem path resolution is unchanged.
- `loadStepNamespace` re-introduces the cache check — safe now because the (journey, step) namespace is unique.
- Existing user-land call sites that pass `getTranslationFunction(req, 'step-name', ['common'])` continue to work — the function reads the journey from `res.locals.step` automatically. They can be simplified to `getTranslationFunction(req)` over time if desired.

### Tests

- `i18n.test.ts`: new tests for journey-scoped namespace, cache short-circuit, cross-journey isolation, and `res.locals.step` fallback. Existing assertions for namespace shape updated.
- `registerSteps.test.ts`: middleware-stack length assertions adjusted for the new `stepContext` frame; new test confirms the middleware actually writes `res.locals.step`.

All 1629 unit tests pass; `tsc --noEmit` clean; eslint + prettier clean on changed files.

## Test plan

- [ ] CI green
- [ ] Smoke test: open `/case/<id>/respond-to-claim/start-now` and `/case/<id>/upload-additional-documents` in the same session, confirm each shows its own translations (no cross-talk)
- [ ] Logs: confirm no per-request "translation file" disk-read churn after the first hit per (journey, step, lang)