### PR TITLE
Stop mutating shared nunjucks env per request

### DIFF
--- a/src/main/middleware/oidc.ts
+++ b/src/main/middleware/oidc.ts
@@ -108,8 +108,8 @@ export const oidcMiddleware: RequestHandler = async (
         if (!req.session?.user) {
           return setReturnToAndRedirectToLogin();
         }
-        // Update nunjucks global and continue
-        req.app.locals.nunjucksEnv.addGlobal('user', req.session.user);
+        // Expose user to templates via per-request res.locals (not a shared nunjucks global)
+        res.locals.user = req.session.user;
         return next();
       }
 
@@ -186,8 +186,8 @@ export const oidcMiddleware: RequestHandler = async (
       }
     }
 
-    // Token is valid, update nunjucks global and continue
-    req.app.locals.nunjucksEnv.addGlobal('user', req.session.user);
+    // Token is valid; expose user to templates via per-request res.locals
+    res.locals.user = req.session.user;
     next();
   } catch (error) {
     logger.error('Unexpected error in oidcMiddleware', {

--- a/src/main/modules/i18n/index.ts
+++ b/src/main/modules/i18n/index.ts
@@ -6,7 +6,6 @@ import type { Express, NextFunction, Request, Response } from 'express';
 import i18next, { type InitOptions, type TFunction } from 'i18next';
 import Backend from 'i18next-fs-backend';
 import { LanguageDetector, handle as i18nextHandle } from 'i18next-http-middleware';
-import type { Environment } from 'nunjucks';
 import { z } from 'zod';
 import { makeZodI18nMap } from 'zod-i18n-map';
 
@@ -149,16 +148,6 @@ export function populateCommonTranslations(req: Request, res: Response, t: TFunc
   }
 }
 
-/** Sets up Nunjucks globals for i18n. */
-export function setupNunjucksGlobals(env: Environment | undefined, globals: Record<string, unknown>): void {
-  if (!env) {
-    return;
-  }
-  for (const [key, value] of Object.entries(globals)) {
-    env.addGlobal(key, value);
-  }
-}
-
 /** Creates i18next configuration. */
 function createI18nextConfig(localesDir: string, namespaces: string[]): InitOptions {
   return {
@@ -234,8 +223,6 @@ export class I18n {
 
       res.locals.lang = lang;
       res.locals.t = t;
-
-      setupNunjucksGlobals(req.app.locals?.nunjucksEnv, { lang, t });
 
       next();
     });

--- a/src/test/unit/middleware/oidc.test.ts
+++ b/src/test/unit/middleware/oidc.test.ts
@@ -109,6 +109,7 @@ describe('oidcMiddleware', () => {
     };
     mockResponse = {
       redirect: jest.fn(),
+      locals: {},
     };
     nextFunction = jest.fn();
   });
@@ -137,10 +138,7 @@ describe('oidcMiddleware', () => {
     expect(nextFunction).toHaveBeenCalled();
     expect(mockResponse.redirect).not.toHaveBeenCalled();
     expect(mockOidcModule.refreshUserTokens).not.toHaveBeenCalled();
-    expect(mockRequest.app?.locals.nunjucksEnv.addGlobal).toHaveBeenCalledWith(
-      'user',
-      (mockRequest.session as CustomSession).user
-    );
+    expect(mockResponse.locals?.user).toBe((mockRequest.session as CustomSession).user);
   });
 
   it('should redirect to /login when user is not present in session', async () => {

--- a/src/test/unit/modules/i18n/index.test.ts
+++ b/src/test/unit/modules/i18n/index.test.ts
@@ -12,7 +12,6 @@ import {
   getCommonTranslations,
   getTranslationFunction,
   populateCommonTranslations,
-  setupNunjucksGlobals,
 } from '@modules/i18n';
 import { Logger } from '@modules/logger';
 
@@ -106,7 +105,7 @@ describe('i18n module', () => {
     // Error was logged
     expect(mockLogger.error).toHaveBeenCalledWith('[i18n] init error', err);
   });
-  it('middleware clamps language, calls changeLanguage, exposes t and sets nunjucks globals (valid lang)', async () => {
+  it('middleware clamps language, calls changeLanguage and exposes lang+t on res.locals (valid lang)', async () => {
     // Make init succeed
     mockInit.mockImplementation((_opts: unknown, cb: (err: unknown) => void) => cb(null));
 
@@ -118,13 +117,11 @@ describe('i18n module', () => {
     const langMw = (app.use as jest.Mock).mock.calls[1][0] as (req: any, res: any, next: any) => void;
 
     const changeLanguage = jest.fn();
-    const addGlobal = jest.fn();
 
     const req = {
       language: 'cy',
       i18n: { changeLanguage },
       t: (key: string | string[], def?: string) => (Array.isArray(key) ? (def ?? key[0]) : (def ?? key)),
-      app: { locals: { nunjucksEnv: { addGlobal } } },
       session: { user: { name: 'Alice' } },
     } as unknown as Parameters<typeof langMw>[0];
 
@@ -136,15 +133,11 @@ describe('i18n module', () => {
     // changeLanguage called with clamped 'cy'
     expect(changeLanguage).toHaveBeenCalledWith('cy');
 
-    // res.locals populated
+    // res.locals populated (request-scoped, not shared nunjucks globals)
     expect(res.locals.lang).toBe('cy');
     expect(typeof res.locals.t).toBe('function');
 
     expect(res.locals.t('serviceName', 'Default Service')).toBe('Default Service');
-
-    // nunjucks globals set
-    expect(addGlobal).toHaveBeenCalledWith('lang', 'cy');
-    expect(addGlobal).toHaveBeenCalledWith('t', expect.any(Function));
 
     // next called
     expect(next).toHaveBeenCalled();
@@ -161,13 +154,11 @@ describe('i18n module', () => {
     const langMw = (app.use as jest.Mock).mock.calls[1][0] as (req: any, res: any, next: any) => void;
 
     const changeLanguage = jest.fn();
-    const addGlobal = jest.fn();
 
     const req = {
       language: 'fr', // invalid -> should clamp to 'en'
       i18n: { changeLanguage },
       // no req.t -> middleware must provide fallback TFunction
-      app: { locals: { nunjucksEnv: { addGlobal } } },
       session: {}, // no user
     } as unknown as Parameters<typeof langMw>[0];
 
@@ -187,11 +178,8 @@ describe('i18n module', () => {
     // @ts-expect-error runtime call for test
     expect(res.locals.t(['k1', 'k2'], undefined)).toBe('k1'); // returns first key when no default
 
-    // nunjucks globals set (lang & t); no user global when absent
-    expect(addGlobal).toHaveBeenCalledWith('lang', 'en');
-    expect(addGlobal).toHaveBeenCalledWith('t', expect.any(Function));
-    // ensure we did NOT push a user global
-    expect(addGlobal).not.toHaveBeenCalledWith('user', expect.anything());
+    // user is exposed to templates by oidcMiddleware, not the i18n middleware
+    expect(res.locals.user).toBeUndefined();
 
     expect(next).toHaveBeenCalled();
   });
@@ -328,25 +316,6 @@ describe('i18n module', () => {
       populateCommonTranslations(req, res, mockT);
 
       expect(res.locals.serviceName).toBe('Existing Service');
-    });
-  });
-
-  describe('setupNunjucksGlobals', () => {
-    it('should add globals to nunjucks environment', () => {
-      const addGlobal = jest.fn();
-      const env = { addGlobal } as any;
-      const globals = { lang: 'en', t: jest.fn() };
-
-      setupNunjucksGlobals(env, globals);
-
-      expect(addGlobal).toHaveBeenCalledWith('lang', 'en');
-      expect(addGlobal).toHaveBeenCalledWith('t', globals.t);
-    });
-
-    it('should return early if env is undefined', () => {
-      const globals = { lang: 'en', t: jest.fn() };
-
-      expect(() => setupNunjucksGlobals(undefined, globals)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary

The Nunjucks `Environment` built once at boot in `modules/nunjucks/index.ts:23` lives on `app.locals.nunjucksEnv` — a **process-wide singleton**. Three middleware call sites mutate it on every authenticated request:

- `middleware/oidc.ts:112, 190` — `nunjucksEnv.addGlobal('user', req.session.user)`
- `modules/i18n/index.ts:238` — `setupNunjucksGlobals(env, { lang, t })` → `addGlobal('lang', …)` + `addGlobal('t', …)`

Node is single-threaded per tick but every `await` is a context switch, so request A's controller can yield (e.g. on a CCD fetch) and request B's middleware then overwrites the global before A renders. With concurrent traffic the value on the env is whichever request wrote last — a cross-user data leak for any template that reads `{{ user.* }}`.

The `user` global isn't currently read by any template (`grep -rn "{{ *user\b\|user\." src/main/views/ src/main/steps/` returns zero matches outside the third-party `govuk/`/`hmcts/` libraries), so today it's a dead write. But it's a trap for the next person who adds `{{ user.firstName }}` to a header partial. The `lang` and `t` globals are saved by the fact that `res.locals.lang` and `res.locals.t` are set two lines earlier (`modules/i18n/index.ts:235-236`) and Nunjucks resolves render-context values before falling back to globals — so they're pure duplication of request-scoped values.

## Changes

- `middleware/oidc.ts` — replace both `nunjucksEnv.addGlobal('user', …)` calls with `res.locals.user = req.session.user`.
- `modules/i18n/index.ts` — delete the `setupNunjucksGlobals` call from the per-request middleware (the matching `res.locals.lang` / `res.locals.t` writes immediately above stay). Remove the now-unused `setupNunjucksGlobals` export and the `Environment` import.
- Test updates in `middleware/oidc.test.ts` and `modules/i18n/index.test.ts` to assert on `res.locals` instead of `addGlobal` calls. Drops the standalone `setupNunjucksGlobals` describe block.

Templates do not need to change — `res.render(view, data)` merges `app.locals` + `res.locals` + `data` into the Nunjucks render context, so `{{ user.* }}`, `{{ lang }}`, `{{ t(...) }}` resolve exactly as before, but request-scoped.

## Test plan

- [x] `yarn test:unit` — 1611 passing
- [x] `yarn lint` — clean
- [ ] Smoke test on a deployed preview env that the dashboard and a step page still render with the right language and (when reintroduced) the right user details