### PR TITLE
Replace in-process concurrency Maps with Redis-backed locks

### DIFF
--- a/src/main/middleware/oidc.ts
+++ b/src/main/middleware/oidc.ts
@@ -1,31 +1,57 @@
 import config from 'config';
-import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { type Request, type RequestHandler } from 'express';
+import type { SessionData } from 'express-session';
 import * as jose from 'jose';
 
 import { Logger } from '@modules/logger';
+import { RedisLockTimeoutError, withRedisLock } from '@modules/redisLock';
 
 const logger = Logger.getLogger('oidcMiddleware');
 
-// In-memory map to prevent parallel refresh attempts for the same session
-const refreshInProgress = new Map<string, Promise<void>>();
-const REFRESH_TIMEOUT_MS = 10000; // 10 seconds timeout for refresh operations
+const REFRESH_LOCK_TTL_MS = 15_000;
+const REFRESH_LOCK_WAIT_TIMEOUT_MS = 10_000;
 
-/** Clears the refresh-in-progress map. Exported for tests only. */
-export const clearRefreshInProgressForTesting = (): void => refreshInProgress.clear();
+function shouldRefreshAccessToken(accessToken: string | undefined): boolean {
+  if (!accessToken) {
+    return true;
+  }
+  try {
+    const decoded = jose.decodeJwt(accessToken);
+    if (!decoded.exp) {
+      return true;
+    }
+    const earlyRefreshSeconds = config.get<number>('oidc.accessTokenEarlyRefreshSeconds');
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    return nowSeconds >= decoded.exp - earlyRefreshSeconds;
+  } catch {
+    return true;
+  }
+}
+
+function readSessionFromStore(req: Request): Promise<SessionData | null> {
+  return new Promise((resolve, reject) => {
+    if (!req.sessionStore?.get) {
+      resolve(null);
+      return;
+    }
+    req.sessionStore.get(req.sessionID, (err, sess) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(sess ?? null);
+      }
+    });
+  });
+}
 
 /**
- * Authentication middleware that checks token expiry and refreshes if needed
- * @param req
- * @param res
- * @param next
+ * Authentication middleware that checks token expiry and refreshes if needed.
+ * Refresh is serialised per session via a Redis-backed lock so concurrent
+ * requests on multiple pods don't each fire a refresh against IDAM with the
+ * same refresh token.
  */
-export const oidcMiddleware: RequestHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void> => {
+export const oidcMiddleware: RequestHandler = async (req, res, next): Promise<void> => {
   try {
-    // Only set returnTo when about to redirect to login (avoids overwriting on every request which can cause loops)
     const setReturnToAndRedirectToLogin = (): void => {
       if (req.session && !req.session.returnTo) {
         req.session.returnTo = req.originalUrl;
@@ -38,84 +64,49 @@ export const oidcMiddleware: RequestHandler = async (
     }
 
     const user = req.session.user;
-
     const { accessToken, refreshToken } = user;
 
     if (!accessToken) {
-      if (req.session) {
-        delete req.session.user;
-      }
+      delete req.session.user;
       return setReturnToAndRedirectToLogin();
     }
 
-    // Decode JWT to check expiry
-    let tokenExp: number | undefined;
-    let shouldRefresh = false;
-
-    try {
-      const decoded = jose.decodeJwt(accessToken);
-      tokenExp = decoded.exp;
-
-      if (tokenExp) {
-        const accessTokenEarlyRefreshSeconds = config.get<number>('oidc.accessTokenEarlyRefreshSeconds');
-        const nowSeconds = Math.floor(Date.now() / 1000);
-        const expiryThreshold = tokenExp - accessTokenEarlyRefreshSeconds;
-        shouldRefresh = nowSeconds >= expiryThreshold;
-      } else {
-        // If no exp claim, assume expired to be safe
-        shouldRefresh = true;
-      }
-    } catch (error) {
-      // If decoding fails, assume expired
-      shouldRefresh = true;
-      logger.warn('Failed to decode access token, treating as expired', {
-        event: 'token_refresh_attempt',
-        userId: user.uid,
-        path: req.originalUrl,
-        reason: 'decode_failed',
-        error: error instanceof Error ? error.message : String(error),
-      });
+    if (!shouldRefreshAccessToken(accessToken)) {
+      req.app.locals.nunjucksEnv.addGlobal('user', req.session.user);
+      return next();
     }
 
-    // If token is expired or near-expiry, attempt refresh
-    if (shouldRefresh) {
-      if (!refreshToken) {
-        if (req.session) {
-          delete req.session.user;
-        }
-        return setReturnToAndRedirectToLogin();
-      }
+    if (!refreshToken) {
+      delete req.session.user;
+      return setReturnToAndRedirectToLogin();
+    }
 
-      // Check if refresh is already in progress for this session
-      const sessionId = req.sessionID;
-      const existingRefresh = refreshInProgress.get(sessionId);
+    const redis = req.app.locals.redisClient;
+    if (!redis) {
+      logger.error('redisClient missing on app.locals; cannot coordinate token refresh');
+      return next(new Error('redisClient not configured'));
+    }
 
-      if (existingRefresh) {
-        // Wait for existing refresh to complete
-        try {
-          await existingRefresh;
-        } catch (error) {
-          // If refresh failed, continue to handle it below
-          logger.error('Refresh failed, continuing to handle it below', {
-            event: 'token_refresh_failure',
-            userId: user.uid,
-            path: req.originalUrl,
-            reason: 'refresh_failed',
-            error: error instanceof Error ? error.message : String(error),
+    try {
+      await withRedisLock(
+        redis,
+        `pcs:oidc-refresh:${req.sessionID}`,
+        { ttlMs: REFRESH_LOCK_TTL_MS, waitTimeoutMs: REFRESH_LOCK_WAIT_TIMEOUT_MS },
+        async () => {
+          // Another pod (or an earlier waiter) may have already refreshed for
+          // this session. Re-read from the store and adopt if fresh.
+          const fresh = await readSessionFromStore(req).catch(err => {
+            logger.warn('Failed to re-read session from store after acquiring refresh lock', {
+              userId: user.uid,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
           });
-        }
-        // Re-check user after refresh (might have been cleared)
-        if (!req.session?.user) {
-          return setReturnToAndRedirectToLogin();
-        }
-        // Update nunjucks global and continue
-        req.app.locals.nunjucksEnv.addGlobal('user', req.session.user);
-        return next();
-      }
+          if (fresh?.user?.accessToken && !shouldRefreshAccessToken(fresh.user.accessToken)) {
+            req.session.user = fresh.user;
+            return;
+          }
 
-      // Start new refresh
-      const refreshPromise = (async () => {
-        try {
           const oidcModule = req.app.locals.oidc;
           if (!oidcModule) {
             throw new Error('OIDC module not available in app.locals');
@@ -135,58 +126,40 @@ export const oidcMiddleware: RequestHandler = async (
             path: req.originalUrl,
           });
 
-          // Update session with new tokens
           req.session.user = {
             ...user,
             accessToken: refreshResult.accessToken,
             refreshToken: refreshResult.refreshToken || refreshToken,
             idToken: refreshResult.idToken || user.idToken,
           };
-        } catch (error) {
-          logger.error('Token refresh failed', {
-            event: 'token_refresh_failure',
-            userId: user.uid,
-            path: req.originalUrl,
-            reason: 'refresh_failed',
-            error: error instanceof Error ? error.message : String(error),
-          });
-
-          // Clear session on refresh failure
-          if (req.session) {
-            delete req.session.user;
-          }
-
-          throw error;
-        } finally {
-          // Clean up refresh tracking after timeout
-          setTimeout(() => {
-            refreshInProgress.delete(sessionId);
-          }, REFRESH_TIMEOUT_MS);
         }
-      })();
+      );
+    } catch (error) {
+      const reason = error instanceof RedisLockTimeoutError ? 'lock_timeout' : 'refresh_failed';
+      logger.error('Token refresh failed', {
+        event: 'token_refresh_failure',
+        userId: user.uid,
+        path: req.originalUrl,
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
 
-      refreshInProgress.set(sessionId, refreshPromise);
-
-      try {
-        await refreshPromise;
-      } catch {
-        // Refresh failed, redirect to login
-        logger.info('Redirecting to login due to refresh failure', {
-          event: 'redirect_to_login',
-          userId: user.uid,
-          path: req.originalUrl,
-          reason: 'refresh_failed',
-        });
-        return setReturnToAndRedirectToLogin();
+      if (req.session) {
+        delete req.session.user;
       }
-
-      // Re-check user after refresh (might have been cleared)
-      if (!req.session?.user) {
-        return setReturnToAndRedirectToLogin();
-      }
+      logger.info('Redirecting to login due to refresh failure', {
+        event: 'redirect_to_login',
+        userId: user.uid,
+        path: req.originalUrl,
+        reason,
+      });
+      return setReturnToAndRedirectToLogin();
     }
 
-    // Token is valid, update nunjucks global and continue
+    if (!req.session?.user) {
+      return setReturnToAndRedirectToLogin();
+    }
+
     req.app.locals.nunjucksEnv.addGlobal('user', req.session.user);
     next();
   } catch (error) {

--- a/src/main/modules/redisLock/index.ts
+++ b/src/main/modules/redisLock/index.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'crypto';
+
+import type { Redis } from 'ioredis';
+
+import { Logger } from '@modules/logger';
+
+const logger = Logger.getLogger('redisLock');
+
+export interface RedisLockOptions {
+  /** TTL of the lock key in milliseconds. The lock is auto-released after this if the holder crashes. */
+  ttlMs: number;
+  /** Maximum time to wait for the lock before giving up. Defaults to 5000ms. */
+  waitTimeoutMs?: number;
+  /** Polling interval while waiting to acquire. Defaults to 50ms. */
+  retryDelayMs?: number;
+}
+
+export class RedisLockTimeoutError extends Error {
+  constructor(key: string, waitTimeoutMs: number) {
+    super(`Failed to acquire Redis lock '${key}' within ${waitTimeoutMs}ms`);
+    this.name = 'RedisLockTimeoutError';
+  }
+}
+
+// Only delete the key if its value matches our token — prevents one holder
+// from releasing another's lock if the first holder's TTL expired mid-work.
+const RELEASE_SCRIPT =
+  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
+
+/**
+ * Run `fn` while holding a Redis-backed mutex on `key`. Acquires with `SET NX PX`,
+ * polls until acquired or `waitTimeoutMs` elapses, releases via a token-checked
+ * Lua script. Use for cross-pod serialization (multiple Node processes sharing Redis).
+ */
+export async function withRedisLock<T>(
+  redis: Redis,
+  key: string,
+  options: RedisLockOptions,
+  fn: () => Promise<T>
+): Promise<T> {
+  const token = randomUUID();
+  const waitTimeoutMs = options.waitTimeoutMs ?? 5000;
+  const retryDelayMs = options.retryDelayMs ?? 50;
+  const deadline = Date.now() + waitTimeoutMs;
+
+  while (true) {
+    const acquired = await redis.set(key, token, 'PX', options.ttlMs, 'NX');
+    if (acquired === 'OK') {
+      try {
+        return await fn();
+      } finally {
+        try {
+          await redis.eval(RELEASE_SCRIPT, 1, key, token);
+        } catch (err) {
+          logger.warn('Failed to release Redis lock; relying on TTL', {
+            key,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+    if (Date.now() >= deadline) {
+      throw new RedisLockTimeoutError(key, waitTimeoutMs);
+    }
+    await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+  }
+}

--- a/src/main/routes/documentProxy.ts
+++ b/src/main/routes/documentProxy.ts
@@ -10,6 +10,7 @@ import { getUserToken } from '../steps/utils';
 
 import type { DocumentStorage } from '@modules/documents/storage';
 import { Logger } from '@modules/logger';
+import { withRedisLock } from '@modules/redisLock';
 import type { CcdCollectionItem, CcdUploadedDocument } from '@services/ccdCase.interface';
 import { deleteDocument, getDocumentBinary, uploadDocument } from '@services/cdamService';
 import type { CdamDocument } from '@services/documentUpload.interface';
@@ -81,33 +82,27 @@ function uploadCtx(req: Request): { storage: DocumentStorage } {
   return { storage: step.documentStorage };
 }
 
-// Per-case in-process mutex. Two concurrent uploads/deletes for the same case
+// Per-case cross-pod mutex. Two concurrent uploads/deletes for the same case
 // can otherwise race on the read-modify-write of the documents collection and
 // silently drop entries. The lock serialises only the cheap append-and-save
 // phase; CDAM uploads run in parallel outside the lock.
-const caseLocks = new Map<string, Promise<void>>();
+const CASE_LOCK_TTL_MS = 30_000;
+const CASE_LOCK_WAIT_TIMEOUT_MS = 15_000;
 
-async function withCaseLock<T>(caseId: string, fn: () => Promise<T>): Promise<T> {
-  const previous = caseLocks.get(caseId) ?? Promise.resolve();
-  let release!: () => void;
-  const myTail = previous.then(() => new Promise<void>(resolve => (release = resolve)));
-  caseLocks.set(caseId, myTail);
-  try {
-    await previous;
-    return await fn();
-  } finally {
-    release();
-    if (caseLocks.get(caseId) === myTail) {
-      caseLocks.delete(caseId);
-    }
-  }
+function caseLock<T>(req: Request, caseId: string, fn: () => Promise<T>): Promise<T> {
+  return withRedisLock(
+    req.app.locals.redisClient,
+    `pcs:case-documents:${caseId}`,
+    { ttlMs: CASE_LOCK_TTL_MS, waitTimeoutMs: CASE_LOCK_WAIT_TIMEOUT_MS },
+    fn
+  );
 }
 
 async function saveDraftWithNewDocument(req: Request, entry: CcdCollectionItem<CcdUploadedDocument>): Promise<number> {
   const caseId = req.params.caseReference as string;
   const { storage } = uploadCtx(req);
 
-  return withCaseLock(caseId, async () => {
+  return caseLock(req, caseId, async () => {
     const existing = await storage.readFresh(req);
     const updated = [...existing, entry];
     await storage.save(req, updated);
@@ -119,7 +114,7 @@ async function removeDraftDocument(req: Request, docId: string): Promise<'remove
   const caseId = req.params.caseReference as string;
   const { storage } = uploadCtx(req);
 
-  return withCaseLock(caseId, async () => {
+  return caseLock(req, caseId, async () => {
     const existing = await storage.readFresh(req);
     const docToDelete = existing.find(d => d.id === docId);
     if (!docToDelete) {

--- a/src/test/unit/middleware/oidc.test.ts
+++ b/src/test/unit/middleware/oidc.test.ts
@@ -4,7 +4,7 @@ import { Session } from 'express-session';
 import * as jose from 'jose';
 import { UserInfoResponse } from 'openid-client';
 
-import { clearRefreshInProgressForTesting, oidcMiddleware } from '../../../main/middleware/oidc';
+import { oidcMiddleware } from '../../../main/middleware/oidc';
 import type { OIDCModule } from '../../../main/modules/oidc';
 
 interface CustomSession extends Session {
@@ -28,6 +28,10 @@ jest.mock('@modules/logger', () => ({
       error: jest.fn(),
     }),
   },
+}));
+jest.mock('@modules/redisLock', () => ({
+  withRedisLock: jest.fn(async (_redis: unknown, _key: string, _options: unknown, fn: () => Promise<unknown>) => fn()),
+  RedisLockTimeoutError: class extends Error {},
 }));
 
 // Create a minimal mock i18n object to satisfy type requirements
@@ -55,7 +59,6 @@ describe('oidcMiddleware', () => {
   };
 
   beforeEach(() => {
-    clearRefreshInProgressForTesting();
     jest.clearAllMocks();
 
     (config.get as jest.Mock).mockImplementation((key: string, defaultValue?: unknown) => {
@@ -100,6 +103,7 @@ describe('oidcMiddleware', () => {
             addGlobal: jest.fn(),
           },
           oidc: mockOidcModule as OIDCModule,
+          redisClient: {} as never,
         },
       } as unknown as Application,
       i18n: createMockI18n(),
@@ -323,7 +327,8 @@ describe('oidcMiddleware', () => {
     expect(nextFunction).toHaveBeenCalled();
   });
 
-  it('should prevent parallel refresh attempts for same session', async () => {
+  it('coordinates refresh via the Redis lock keyed by session id', async () => {
+    const { withRedisLock } = jest.requireMock('@modules/redisLock');
     const expiredToken = createValidToken(-60);
     (mockRequest.session as CustomSession).user = {
       sub: '123',
@@ -338,38 +343,63 @@ describe('oidcMiddleware', () => {
       sub: 'test-user',
     });
 
-    // Create a promise that resolves after a delay
-    let resolveRefresh: (value: unknown) => void;
-    const delayedRefresh = new Promise(resolve => {
-      resolveRefresh = resolve;
-    });
-
-    (mockOidcModule.refreshUserTokens as jest.Mock).mockReturnValue(delayedRefresh);
-
-    // Start first middleware call
-    const promise1 = oidcMiddleware(
-      mockRequest as Request & { i18n: import('i18next').i18n; t: import('i18next').TFunction },
-      mockResponse as Response,
-      nextFunction
-    );
-
-    // Start second middleware call (should wait for first)
-    const promise2 = oidcMiddleware(
-      mockRequest as Request & { i18n: import('i18next').i18n; t: import('i18next').TFunction },
-      mockResponse as Response,
-      nextFunction
-    );
-
-    // Resolve the refresh
-    resolveRefresh!({
+    (mockOidcModule.refreshUserTokens as jest.Mock).mockResolvedValue({
       accessToken: createValidToken(3600),
       refreshToken: 'new-refresh-token',
       accessTokenExp: Math.floor(Date.now() / 1000) + 3600,
     });
 
-    await Promise.all([promise1, promise2]);
+    await oidcMiddleware(
+      mockRequest as Request & { i18n: import('i18next').i18n; t: import('i18next').TFunction },
+      mockResponse as Response,
+      nextFunction
+    );
 
-    // Should only call refresh once
-    expect(mockOidcModule.refreshUserTokens).toHaveBeenCalledTimes(1);
+    expect(withRedisLock).toHaveBeenCalledWith(
+      expect.anything(),
+      'pcs:oidc-refresh:test-session-id',
+      expect.objectContaining({ ttlMs: expect.any(Number), waitTimeoutMs: expect.any(Number) }),
+      expect.any(Function)
+    );
+  });
+
+  it('adopts the freshly-refreshed session from the store and skips its own refresh', async () => {
+    const expiredToken = createValidToken(-60);
+    const freshToken = createValidToken(3600);
+    (mockRequest.session as CustomSession).user = {
+      sub: '123',
+      uid: 'test-uid',
+      accessToken: expiredToken,
+      idToken: 'id-token',
+      refreshToken: 'refresh-token',
+    };
+
+    // jose.decodeJwt: the expired token decodes to past-exp; the fresh token decodes to future-exp.
+    (jose.decodeJwt as jest.Mock).mockImplementation((token: string) =>
+      token === freshToken
+        ? { exp: Math.floor(Date.now() / 1000) + 3600, sub: 'test-user' }
+        : { exp: Math.floor(Date.now() / 1000) - 60, sub: 'test-user' }
+    );
+
+    // sessionStore.get returns a session that already holds the fresh token —
+    // simulating another pod (or earlier waiter) having just refreshed.
+    (mockRequest as Partial<Request>).sessionStore = {
+      get: jest.fn((_sid: string, cb: (err: unknown, sess: unknown) => void) =>
+        cb(null, {
+          cookie: {},
+          user: { sub: '123', uid: 'test-uid', accessToken: freshToken, idToken: 'id', refreshToken: 'r' },
+        })
+      ),
+    } as unknown as Request['sessionStore'];
+
+    await oidcMiddleware(
+      mockRequest as Request & { i18n: import('i18next').i18n; t: import('i18next').TFunction },
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(mockOidcModule.refreshUserTokens).not.toHaveBeenCalled();
+    expect((mockRequest.session as CustomSession).user?.accessToken).toBe(freshToken);
+    expect(nextFunction).toHaveBeenCalled();
   });
 });

--- a/src/test/unit/modules/redisLock/index.test.ts
+++ b/src/test/unit/modules/redisLock/index.test.ts
@@ -1,0 +1,131 @@
+import type { Redis } from 'ioredis';
+
+import { RedisLockTimeoutError, withRedisLock } from '@modules/redisLock';
+
+jest.mock('@modules/logger', () => ({
+  Logger: { getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }) },
+}));
+
+// Minimal in-memory fake of the ioredis methods we use, enough to model
+// SET NX PX (with TTL expiry) and the token-checked Lua release.
+function createFakeRedis(): Redis {
+  const store = new Map<string, { value: string; expiresAt: number }>();
+
+  const get = (key: string): string | null => {
+    const entry = store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (Date.now() >= entry.expiresAt) {
+      store.delete(key);
+      return null;
+    }
+    return entry.value;
+  };
+
+  return {
+    set: jest.fn(async (key: string, value: string, _pxFlag: string, ttlMs: number, _nxFlag: string) => {
+      if (get(key) !== null) {
+        return null;
+      }
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+      return 'OK';
+    }),
+    eval: jest.fn(async (_script: string, _numKeys: number, key: string, token: string) => {
+      const current = get(key);
+      if (current === token) {
+        store.delete(key);
+        return 1;
+      }
+      return 0;
+    }),
+  } as unknown as Redis;
+}
+
+describe('withRedisLock', () => {
+  it('acquires when the key is free and releases on success', async () => {
+    const redis = createFakeRedis();
+    const result = await withRedisLock(redis, 'k', { ttlMs: 1000 }, async () => 'ok');
+    expect(result).toBe('ok');
+    expect(redis.set).toHaveBeenCalledWith('k', expect.any(String), 'PX', 1000, 'NX');
+    expect(redis.eval).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases on inner throw and rethrows', async () => {
+    const redis = createFakeRedis();
+    await expect(
+      withRedisLock(redis, 'k', { ttlMs: 1000 }, async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+    expect(redis.eval).toHaveBeenCalledTimes(1);
+  });
+
+  it('serialises concurrent holders for the same key', async () => {
+    const redis = createFakeRedis();
+    const events: string[] = [];
+
+    const run = (label: string): Promise<void> =>
+      withRedisLock(redis, 'k', { ttlMs: 5000, retryDelayMs: 5 }, async () => {
+        events.push(`${label}:start`);
+        await new Promise(resolve => setTimeout(resolve, 20));
+        events.push(`${label}:end`);
+      });
+
+    await Promise.all([run('A'), run('B')]);
+
+    // Either A then B, or B then A — but never interleaved.
+    expect([
+      ['A:start', 'A:end', 'B:start', 'B:end'],
+      ['B:start', 'B:end', 'A:start', 'A:end'],
+    ]).toContainEqual(events);
+  });
+
+  it('throws RedisLockTimeoutError if the lock is not acquired within waitTimeoutMs', async () => {
+    const redis = createFakeRedis();
+
+    // Acquire and hold the lock past the second caller's wait timeout.
+    let release!: () => void;
+    const holder = withRedisLock(redis, 'k', { ttlMs: 5000 }, async () => {
+      await new Promise<void>(resolve => {
+        release = resolve;
+      });
+    });
+
+    await expect(
+      withRedisLock(redis, 'k', { ttlMs: 5000, waitTimeoutMs: 30, retryDelayMs: 10 }, async () => 'never')
+    ).rejects.toBeInstanceOf(RedisLockTimeoutError);
+
+    release();
+    await holder;
+  });
+
+  it('does not release a lock owned by a different token', async () => {
+    const redis = createFakeRedis();
+
+    // First holder acquires.
+    let firstFinished = false;
+    const first = withRedisLock(redis, 'k', { ttlMs: 30 }, async () => {
+      await new Promise(resolve => setTimeout(resolve, 60));
+      firstFinished = true;
+    });
+
+    // Wait for the first lock's TTL to lapse, then a second holder acquires.
+    await new Promise(resolve => setTimeout(resolve, 40));
+
+    await withRedisLock(redis, 'k', { ttlMs: 100 }, async () => {
+      // Now the first holder's `finally` runs (when first resolves). Its
+      // eval should NOT delete this second holder's lock because the token
+      // does not match.
+      await first;
+      expect(firstFinished).toBe(true);
+      // Token-mismatch returns 0 from the Lua script — verified by the second
+      // holder's own release at the end of this block succeeding.
+    });
+
+    // Second holder's release should have happened successfully (token match).
+    // Third holder acquires immediately.
+    const result = await withRedisLock(redis, 'k', { ttlMs: 100 }, async () => 'ok');
+    expect(result).toBe('ok');
+  });
+});

--- a/src/test/unit/routes/documentProxy.test.ts
+++ b/src/test/unit/routes/documentProxy.test.ts
@@ -46,6 +46,28 @@ jest.mock('../../../main/middleware', () => ({
   oidcMiddleware: jest.fn((_req: unknown, _res: unknown, next: () => void) => next()),
 }));
 
+// Replace the production Redis-backed lock with an in-process per-key serialiser.
+// The concurrency-safety tests below run several uploads/deletes in parallel
+// against `Promise.all`; we need real serialisation in tests for those assertions
+// to mean anything, but we can't (and shouldn't) stand up a real Redis here.
+jest.mock('../../../main/modules/redisLock', () => {
+  const tails = new Map<string, Promise<unknown>>();
+  return {
+    withRedisLock: jest.fn(async (_redis: unknown, key: string, _opts: unknown, fn: () => Promise<unknown>) => {
+      const previous = tails.get(key) ?? Promise.resolve();
+      const settled = previous.then(() => fn());
+      // Chain the next caller on us; swallow errors so one failing holder
+      // doesn't poison the queue.
+      tails.set(
+        key,
+        settled.catch(() => undefined)
+      );
+      return settled;
+    }),
+    RedisLockTimeoutError: class extends Error {},
+  };
+});
+
 import type { Application, Request, Response } from 'express';
 import multer from 'multer';
 
@@ -79,6 +101,7 @@ function makeReqWithDocs(overrides: Record<string, unknown>, docs: unknown[] = [
   return {
     session: { user: { accessToken: 'token' } },
     params: { caseReference: '123456', journey: 'respond-to-claim', step: 'upload-document' },
+    app: { locals: { redisClient: {} } },
     t: mockT,
     res: {
       locals: {
@@ -652,6 +675,7 @@ describe('documentProxyRoutes', () => {
       const req = {
         session: { user: { accessToken: 'token' } },
         params: { caseReference: '123', journey: 'respond-to-claim', step: 'upload-document' },
+        app: { locals: { redisClient: {} } },
         t: mockT,
         res: { locals: {} },
         body: { delete: 'unknown-id' },
@@ -712,6 +736,7 @@ describe('documentProxyRoutes', () => {
       const baseReq = {
         session: { user: { accessToken: 'token' } },
         params: { caseReference: '123456', journey: 'respond-to-claim', step: 'upload-document' },
+        app: { locals: { redisClient: {} } },
         t: mockT,
         res: { locals: {} },
       };
@@ -753,6 +778,7 @@ describe('documentProxyRoutes', () => {
       const baseReq = {
         session: { user: { accessToken: 'token' } },
         params: { caseReference: '123456', journey: 'respond-to-claim', step: 'upload-document' },
+        app: { locals: { redisClient: {} } },
         t: mockT,
         res: { locals: {} },
       };
@@ -790,6 +816,7 @@ describe('documentProxyRoutes', () => {
       const req = {
         session: { user: { accessToken: 'token' } },
         params: { caseReference: '123456', journey: 'respond-to-claim', step: 'upload-document' },
+        app: { locals: { redisClient: {} } },
         t: mockT,
         res: { locals: { validatedCase: {} } },
         file: makeFile('new.pdf', 99),


### PR DESCRIPTION
## Summary

Two middleware/route layers were using `new Map<string, Promise<…>>` at module scope to serialise per-key operations within one Node process:

- `middleware/oidc.ts` — `refreshInProgress` dedupes concurrent OIDC token refreshes per session.
- `routes/documentProxy.ts` — `caseLocks` serialises the read-modify-write of a case's documents collection across concurrent uploads/deletes.

Both work within one pod and silently fail in multi-pod. PCS frontend runs as multiple AKS replicas, so two requests for the same session/case landing on different pods can both kick off a refresh against IDAM with the same refresh token, or race on the same documents collection and drop entries — exactly the bug the in-process locks were added to prevent.

The oidc cleanup also has a small standalone bug: `setTimeout(() => refreshInProgress.delete(sessionId), REFRESH_TIMEOUT_MS)` either lingers uselessly for 10s after a fast refresh, or deletes the in-progress entry while a slow refresh is still running, allowing a second refresh to start.

## Changes

- **New `modules/redisLock`** — small helper exposing `withRedisLock(redis, key, options, fn)`. Acquires with `SET NX PX`, releases via a token-checked Lua script so one holder can't release another's lock if its TTL lapsed mid-work, polls until acquired or `waitTimeoutMs` elapses. No new dependency (just `ioredis` which is already pulled in).
- **`middleware/oidc.ts`** — refresh serialised by `pcs:oidc-refresh:${sessionID}`. After acquiring the lock, the middleware re-reads the session from the store: if another pod just refreshed for this session, it adopts those tokens instead of firing a duplicate refresh. The buggy `setTimeout` cleanup is gone; the Lua-script release runs in a `finally`, with the 15s TTL as a backstop. Refresh-state inference is also pulled into a small `shouldRefreshAccessToken` helper so the same JWT-expiry check runs both before lock acquisition and against the freshly-read store value.
- **`routes/documentProxy.ts`** — case lock keyed `pcs:case-documents:${caseId}`. The `withCaseLock` helper and `caseLocks` Map are gone.

## Tests

- New unit tests for `withRedisLock`: acquire, release on success, release on inner throw, serialises concurrent holders for the same key, `RedisLockTimeoutError` on wait timeout, token-mismatched release does not delete someone else's lock.
- `middleware/oidc.test.ts` — the old "should prevent parallel refresh attempts" test was tightly coupled to the in-process Map sharing two callers the same promise. Replaced with two tests: one asserting `withRedisLock` is invoked with `pcs:oidc-refresh:${sessionID}` and sensible options, one asserting that a freshly-refreshed session from the store is adopted without re-refreshing.
- `routes/documentProxy.test.ts` — mocks `@modules/redisLock` with an in-process per-key serialiser so the existing `Promise.all`-driven concurrency assertions still verify real serialisation against a fake.

## Test plan

- [x] `yarn test:unit` — 1619 passing
- [x] `yarn lint` — clean
- [ ] Smoke test on preview env: parallel uploads on the same case land cleanly; OIDC refresh under load doesn't double-call IDAM