### PR TITLE
 HDPI-4452: Point default API and CCD URLs to AAT

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -23,7 +23,7 @@
     "deadline": 15000
   },
   "api": {
-    "url": "https://pcs-api-pr-1779.preview.platform.hmcts.net"
+    "url": "http://pcs-api-aat.service.core-compute-aat.internal"
   },
   "s2s": {
     "microservice": "pcs_frontend",
@@ -32,7 +32,7 @@
     "key": "s2s:service-token"
   },
   "ccd": {
-    "url": "https://ccd-data-store-api-pcs-api-pr-1779.preview.platform.hmcts.net",
+    "url": "http://ccd-data-store-api-aat.service.core-compute-aat.internal",
     "caseTypeId": "PCS"
   },
   "osPostcodeLookup": {


### PR DESCRIPTION
### Jira link


### Change description
Updates config/default.json so the frontend talks to shared AAT services instead of PR-1779 preview endpoints:




### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
