### PR TITLE
HDPI-7269-DisableErrorMessageTestFromMaster

### DIFF
--- a/src/test/ui/functionalValidationTest/respondToAClaim.errorMessageValidation.spec.ts
+++ b/src/test/ui/functionalValidationTest/respondToAClaim.errorMessageValidation.spec.ts
@@ -238,7 +238,7 @@ test.afterEach(() => {
 });
 
 test.describe('Respond to claim — ErrorMessageValidation(EMV) journey @nightly @EMV', () => {
-  test('RentArrears - Introductory - NoticeServed - Yes and NoticeDateProvided - No - NoticeDetails- Yes - Notice date unknown @regression', async () => {
+  test('RentArrears - Introductory - NoticeServed - Yes and NoticeDateProvided - No - NoticeDetails- Yes - Notice date unknown', async () => {
     await softErrorMessageValidation('freeLegalAdvice', freeLegalAdviceErrorValidation);
     await performAction('selectLegalAdvice', freeLegalAdvice.noRadioOption);
     await performAction('selectDoYouHaveASolicitor', doYouHaveASolicitor.noRadioOption);
@@ -492,7 +492,7 @@ test.describe('Respond to claim — ErrorMessageValidation(EMV) journey @nightly
     assertAllErrorMessageValidations();
   });
 
-  test('NonRentArrears - Secure - NoticeServed - Yes and NoticeDateProvided - Yes - NoticeDetails- Yes - Notice date known @secureFlexible @regression', async () => {
+  test('NonRentArrears - Secure - NoticeServed - Yes and NoticeDateProvided - Yes - NoticeDetails- Yes - Notice date known @secureFlexible', async () => {
     await softErrorMessageValidation('freeLegalAdvice', freeLegalAdviceErrorValidation);
     await performAction('selectLegalAdvice', freeLegalAdvice.noRadioOption);
     await softErrorMessageValidation('doYouHaveASolicitor', doYouHaveASolicitorErrorValidation);

--- a/src/test/ui/smokeTest/respondToAClaimSmokeTest.spec.ts
+++ b/src/test/ui/smokeTest/respondToAClaimSmokeTest.spec.ts
@@ -31,7 +31,7 @@ test.describe('Respond to a claim - smoke test @health', async () => {
     await performAction('selectLegalAdvice', freeLegalAdvice.yesRadioOption);
   });
 
-  test('Respond to a claim E2E Journey @regression @crossbrowser @sanity', async () => {
+  test('Respond to a claim E2E Journey @crossbrowser @sanity', async () => {
     await performAction('selectLegalAdvice', freeLegalAdvice.yesRadioOption);
     // Below steps will be unskipped once HDPI-5407 and HDPI-5350 are done
     /*await performAction('confirmDefendantDetails', {


### PR DESCRIPTION
### Jira link

See [HDPI-7269](https://tools.hmcts.net/jira/browse/HDPI-7269)

### Change description

Just removed the @regression tag from error message validation, so that these test will not run in the master.

### Testing done
<img width="1725" height="866" alt="Screenshot 2026-06-19 at 14 00 16" src="https://github.com/user-attachments/assets/75af6783-38bc-4160-8ed6-df02efaff38d" />



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
