### PR TITLE
HDPI-7421: Demo env payment return url

### DIFF
--- a/src/main/routes/paymentReturn.ts
+++ b/src/main/routes/paymentReturn.ts
@@ -13,53 +13,59 @@ function getDefaultReturnPath(caseReference?: string): string {
   return caseReference ? `/case/${caseReference}` : '/';
 }
 
+async function handlePaymentReturnConfirmation(req: Request, res: Response): Promise<void | Response> {
+  const paymentSession = req.session.payment;
+  const accessToken = req.session.user?.accessToken;
+
+  if (!paymentSession?.paymentReference) {
+    logger.warn('Payment return called without payment reference in session');
+    return safeRedirect303(res, '/', '/', ['/']);
+  }
+
+  const internalPaymentReference = req.params.internalReference as string;
+
+  if (!accessToken) {
+    logger.error('Payment return called without user access token');
+    return res.status(401).render('error', { error: 'Authentication required' });
+  }
+
+  const defaultReturnPath = getDefaultReturnPath(paymentSession.caseReference);
+
+  try {
+    const statusResponse = await paymentService.getCardPaymentStatus(accessToken, internalPaymentReference);
+    const outcome = getPaymentOutcome(statusResponse.status);
+
+    const successRedirectUrl = paymentSession.successRedirectUrl || defaultReturnPath;
+    const failureRedirectUrl = paymentSession.failureRedirectUrl || defaultReturnPath;
+    const pendingRedirectUrl = paymentSession.pendingRedirectUrl || failureRedirectUrl;
+
+    let redirectTarget = pendingRedirectUrl;
+
+    if (outcome === 'success') {
+      redirectTarget = successRedirectUrl;
+      await retainPaymentReferenceOnly(req);
+    } else if (outcome === 'failure') {
+      redirectTarget = failureRedirectUrl;
+      await clearPaymentReferenceOnly(req);
+    } else {
+      await retainPaymentReferenceOnly(req);
+    }
+
+    return safeRedirect303(res, redirectTarget, defaultReturnPath, ['/case', '/dashboard', '/payment']);
+  } catch (error) {
+    logger.error('Failed to retrieve card payment status on return callback', error);
+    return safeRedirect303(res, paymentSession.failureRedirectUrl, defaultReturnPath, [
+      '/case',
+      '/dashboard',
+      '/payment',
+    ]);
+  }
+}
+
 export default function paymentReturnRoutes(app: Application): void {
-  app.get('/payment/return/:internalReference/confirmation', oidcMiddleware, async (req: Request, res: Response) => {
-    const paymentSession = req.session.payment;
-    const accessToken = req.session.user?.accessToken;
-
-    if (!paymentSession?.paymentReference) {
-      logger.warn('Payment return called without payment reference in session');
-      return safeRedirect303(res, '/', '/', ['/']);
-    }
-
-    const internalPaymentReference = req.params.internalReference as string;
-
-    if (!accessToken) {
-      logger.error('Payment return called without user access token');
-      return res.status(401).render('error', { error: 'Authentication required' });
-    }
-
-    const defaultReturnPath = getDefaultReturnPath(paymentSession.caseReference);
-
-    try {
-      const statusResponse = await paymentService.getCardPaymentStatus(accessToken, internalPaymentReference);
-      const outcome = getPaymentOutcome(statusResponse.status);
-
-      const successRedirectUrl = paymentSession.successRedirectUrl || defaultReturnPath;
-      const failureRedirectUrl = paymentSession.failureRedirectUrl || defaultReturnPath;
-      const pendingRedirectUrl = paymentSession.pendingRedirectUrl || failureRedirectUrl;
-
-      let redirectTarget = pendingRedirectUrl;
-
-      if (outcome === 'success') {
-        redirectTarget = successRedirectUrl;
-        await retainPaymentReferenceOnly(req);
-      } else if (outcome === 'failure') {
-        redirectTarget = failureRedirectUrl;
-        await clearPaymentReferenceOnly(req);
-      } else {
-        await retainPaymentReferenceOnly(req);
-      }
-
-      return safeRedirect303(res, redirectTarget, defaultReturnPath, ['/case', '/dashboard', '/payment']);
-    } catch (error) {
-      logger.error('Failed to retrieve card payment status on return callback', error);
-      return safeRedirect303(res, paymentSession.failureRedirectUrl, defaultReturnPath, [
-        '/case',
-        '/dashboard',
-        '/payment',
-      ]);
-    }
-  });
+  app.get(
+    '/payment/return/:internalReference/confirmation{/:confirmationToken}',
+    oidcMiddleware,
+    handlePaymentReturnConfirmation
+  );
 }

--- a/src/test/unit/routes/paymentReturn.test.ts
+++ b/src/test/unit/routes/paymentReturn.test.ts
@@ -55,7 +55,7 @@ describe('paymentReturn routes', () => {
   describe('GET /payment/return', () => {
     it('registers route with oidc middleware', () => {
       expect(mockRouterGet).toHaveBeenCalledWith(
-        '/payment/return/:internalReference/confirmation',
+        '/payment/return/:internalReference/confirmation{/:confirmationToken}',
         mockOidcMiddleware,
         expect.any(Function)
       );
@@ -140,6 +140,45 @@ describe('paymentReturn routes', () => {
       expect(req.session.payment).toEqual({
         paymentReference: 'RC-123',
       });
+    });
+
+    it('redirects to success URL when Demo-style confirmation token is present in path', async () => {
+      const handler = mockRouterGet.mock.calls[0][2] as (req: Request, res: Response) => Promise<void>;
+
+      mockGetCardPaymentStatus.mockResolvedValue({ status: 'Success' });
+
+      const req = {
+        session: {
+          user: { accessToken: 'token-123' },
+          payment: {
+            paymentReference: 'RC-123',
+            caseReference: '1234567890123456',
+            successRedirectUrl: '/case/1234567890123456/respond-to-claim/counter-claim-payment-successful',
+            failureRedirectUrl:
+              '/case/1234567890123456/respond-to-claim/counter-claim-application-fee-amount?payment=failed',
+          },
+          save: jest.fn(callback => {
+            callback?.(undefined);
+            return req.session;
+          }),
+        },
+        params: {
+          internalReference: '1f905214-3af0-4f11-a9e7-8b37133bb645',
+          confirmationToken: 'ec9f7e96489a51cd71aa68464833da6597211d811add8f279a6f2423ab58f74f',
+        },
+      } as unknown as Request;
+
+      const res = {
+        redirect: jest.fn(),
+      } as unknown as Response;
+
+      await handler(req, res);
+
+      expect(mockGetCardPaymentStatus).toHaveBeenCalledWith('token-123', '1f905214-3af0-4f11-a9e7-8b37133bb645');
+      expect(res.redirect).toHaveBeenCalledWith(
+        303,
+        '/case/1234567890123456/respond-to-claim/counter-claim-payment-successful'
+      );
     });
 
     it('redirects to failure URL and clears payment reference on failed status', async () => {


### PR DESCRIPTION
### Jira link

See [HDPI-7421](https://tools.hmcts.net/jira/browse/HDPI-7421)

### Change description

In Demo, GovPay redirects the browser back to the PCS frontend with an extra path segment after `/confirmation` (for example `.../confirmation/{token}?language=en`). AAT and Preview use the shorter form without that segment.

The shared card-payment return route only matched the AAT-style URL, so users completing a counterclaim card payment in Demo were sent to a **page not found** error after confirming payment on GovPay.

This change updates the payment return route so the extra Demo segment is accepted.
The same return route is used by other CUI card-payment journeys (for example general applications), so they benefit from the same fix.

### Testing done

- `yarn test:unit src/test/unit/routes/paymentReturn.test.ts` — 8 tests passed, including a new case for the Demo-style URL with an extra confirmation token segment.
- Local route probe (without fix vs with fix): Demo-style return URL returned 404 before the change and matched the route after the change; AAT-style URL continued to match in both cases.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

-   [ ] Yes
-   [x] No

### Checklist

-   [x] commit messages are meaningful and follow good commit message guidelines
-   [ ] README and other documentation has been updated / added (if needed)
-   [x] tests have been updated / new tests has been added (if needed)
-   [ ] Does this PR introduce a breaking change
