### PR TITLE
HDPI-7118: apply Prettier 3.9.4 formatting to fix master lint

### DIFF
--- a/src/main/modules/s2s/index.ts
+++ b/src/main/modules/s2s/index.ts
@@ -61,7 +61,7 @@ export class S2S {
       let serviceToken: string | null = await serviceConfig.redisClient.get(serviceConfig.key);
 
       if (!serviceToken) {
-        const { otp } = TOTP.generate(serviceConfig.secret);
+        const { otp } = await TOTP.generate(serviceConfig.secret);
 
         const params = {
           microservice: serviceConfig.microservice,

--- a/src/main/modules/steps/flow.ts
+++ b/src/main/modules/steps/flow.ts
@@ -419,8 +419,7 @@ export function getStepOrder(flowConfig: JourneyFlowConfig): readonly string[] {
 }
 
 type StepLocation =
-  | { kind: 'section'; sectionIndex: number; stepIndex: number }
-  | { kind: 'nonSection'; stepIndex: number };
+  { kind: 'section'; sectionIndex: number; stepIndex: number } | { kind: 'nonSection'; stepIndex: number };
 
 function locateStep(
   stepName: string,

--- a/src/main/modules/steps/formBuilder/formFieldConfig.interface.ts
+++ b/src/main/modules/steps/formBuilder/formFieldConfig.interface.ts
@@ -6,23 +6,9 @@ import type { DocumentStorage } from '@modules/documents/storage';
 import type { UploadValidationOptions } from '@utils/documentUploadValidation';
 
 export type FormFieldType =
-  | 'radio'
-  | 'checkbox'
-  | 'text'
-  | 'date'
-  | 'textarea'
-  | 'character-count'
-  | 'postcodeLookup'
-  | 'file';
+  'radio' | 'checkbox' | 'text' | 'date' | 'textarea' | 'character-count' | 'postcodeLookup' | 'file';
 export type ComponentType =
-  | 'input'
-  | 'textarea'
-  | 'characterCount'
-  | 'radios'
-  | 'checkboxes'
-  | 'dateInput'
-  | 'postcodeLookup'
-  | 'fileUpload';
+  'input' | 'textarea' | 'characterCount' | 'radios' | 'checkboxes' | 'dateInput' | 'postcodeLookup' | 'fileUpload';
 
 export interface FormFieldOption {
   value?: string;

--- a/src/main/steps/respond-to-claim/regular-expenses/index.ts
+++ b/src/main/steps/respond-to-claim/regular-expenses/index.ts
@@ -450,8 +450,7 @@ export const step: StepDefinition = createRespondToClaimFormStep({
   getInitialFormData: (req: Request) => {
     const caseData = req.res?.locals.validatedCase?.data;
     const draftHc = caseData?.possessionClaimResponse?.defendantResponses?.householdCircumstances as
-      | HouseholdCircumstances
-      | undefined;
+      HouseholdCircumstances | undefined;
 
     if (!draftHc) {
       return {};

--- a/src/main/steps/respond-to-claim/regular-income/index.ts
+++ b/src/main/steps/respond-to-claim/regular-income/index.ts
@@ -148,10 +148,7 @@ export const step: StepDefinition = createRespondToClaimFormStep({
       flagKey: 'incomeFromJobs' | 'pension' | 'universalCredit' | 'otherBenefits',
       amountKey: 'incomeFromJobsAmount' | 'pensionAmount' | 'universalCreditAmount' | 'otherBenefitsAmount',
       frequencyKey:
-        | 'incomeFromJobsFrequency'
-        | 'pensionFrequency'
-        | 'universalCreditFrequency'
-        | 'otherBenefitsFrequency',
+        'incomeFromJobsFrequency' | 'pensionFrequency' | 'universalCreditFrequency' | 'otherBenefitsFrequency',
       amountBodyKey: string,
       frequencyBodyKey: string
     ) => {

--- a/src/main/steps/respond-to-claim/universal-credit/index.ts
+++ b/src/main/steps/respond-to-claim/universal-credit/index.ts
@@ -53,8 +53,7 @@ export const step: StepDefinition = createRespondToClaimFormStep({
   },
   getInitialFormData: req => {
     const householdCircumstances = getValidatedCaseHouseholdCircumstances(req) as
-      | { hasAppliedForUniversalCredit?: string; ucApplicationDate?: string }
-      | undefined;
+      { hasAppliedForUniversalCredit?: string; ucApplicationDate?: string } | undefined;
 
     const data: Record<string, unknown> = {};
     const savedAnswer = fromYesNoEnum(householdCircumstances?.hasAppliedForUniversalCredit);

--- a/src/main/utils/ccdDashboardUtils.ts
+++ b/src/main/utils/ccdDashboardUtils.ts
@@ -48,12 +48,10 @@ export function unwrapNotifications(
 export function unwrapTaskGroups(raw: CcdCollectionItem<CcdDashboardTaskGroup>[] | undefined): DashboardTaskGroup[] {
   return unwrapCollection(raw).map(g => ({
     groupId: g.groupId as DashboardTaskGroup['groupId'],
-    tasks: unwrapCollection(g.tasks).map(
-      (t): DashboardTask => ({
-        templateId: t.templateId,
-        status: t.status,
-      })
-    ),
+    tasks: unwrapCollection(g.tasks).map((t): DashboardTask => ({
+      templateId: t.templateId,
+      status: t.status,
+    })),
   }));
 }
 

--- a/src/test/ui/utils/interfaces/action.interface.ts
+++ b/src/test/ui/utils/interfaces/action.interface.ts
@@ -3,8 +3,7 @@ import { Page } from '@playwright/test';
 export type actionData = string | number | boolean | string[] | object;
 export type actionRecord = Record<string, actionData>;
 export type actionTuple =
-  | [string, actionData | actionRecord]
-  | [string, actionData | actionRecord, actionData | actionRecord];
+  [string, actionData | actionRecord] | [string, actionData | actionRecord, actionData | actionRecord];
 
 export interface IAction {
   execute(

--- a/src/test/unit/steps/respond-to-claim/defendant-name-capture.test.ts
+++ b/src/test/unit/steps/respond-to-claim/defendant-name-capture.test.ts
@@ -112,11 +112,9 @@ describe('respond-to-claim defendant-name-capture step', () => {
 
     const viewModel = res.render.mock.calls[0][1] as { fields: Record<string, unknown>[] };
     const firstNameField = viewModel.fields.find(f => f.name === 'firstName') as
-      | { component?: { label?: { classes?: string }; attributes?: Record<string, unknown> } }
-      | undefined;
+      { component?: { label?: { classes?: string }; attributes?: Record<string, unknown> } } | undefined;
     const lastNameField = viewModel.fields.find(f => f.name === 'lastName') as
-      | { component?: { label?: { classes?: string }; attributes?: Record<string, unknown> } }
-      | undefined;
+      { component?: { label?: { classes?: string }; attributes?: Record<string, unknown> } } | undefined;
 
     expect(firstNameField?.component?.label?.classes).toBe('govuk-label--s');
     expect(firstNameField?.component?.attributes).toEqual(

--- a/src/test/unit/steps/respond-to-claim/installments.test.ts
+++ b/src/test/unit/steps/respond-to-claim/installments.test.ts
@@ -128,8 +128,7 @@ describe('respond-to-claim installments step', () => {
 
     const viewModel = res.render.mock.calls[0][1] as { fields: Record<string, unknown>[] };
     const amountField = viewModel.fields.find(f => f.name === 'installmentAmount') as
-      | { component?: { prefix?: { text?: string } } }
-      | undefined;
+      { component?: { prefix?: { text?: string } } } | undefined;
     expect(amountField?.component?.prefix?.text).toBe('£');
   });
 

--- a/src/types/scss.d.ts
+++ b/src/types/scss.d.ts
@@ -1,0 +1,1 @@
+declare module '*.scss';

--- a/src/types/scss.d.ts
+++ b/src/types/scss.d.ts
@@ -1,1 +1,3 @@
+// Side-effect scss imports are handled by webpack (style/css/sass loaders);
+// typed as an opaque module so tsc doesn't error on them (TS2882 under TS 6+).
 declare module '*.scss';

--- a/src/types/scss.d.ts
+++ b/src/types/scss.d.ts
@@ -1,3 +1,5 @@
-// Side-effect scss imports are handled by webpack (style/css/sass loaders);
-// typed as an opaque module so tsc doesn't error on them (TS2882 under TS 6+).
+// Lets TypeScript accept `import 'file.scss'` statements.
+// Stylesheets are compiled by webpack (sass/css/style loaders), not by tsc, so
+// they have no types. Declaring them as empty modules avoids the compile error
+// TS2882 "Cannot find module or type declarations for ...".
 declare module '*.scss';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "module": "commonjs",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/webpack/govukFrontend.js
+++ b/webpack/govukFrontend.js
@@ -10,13 +10,11 @@ const components = path.resolve(root, 'components');
 const assets = path.resolve(root, 'assets');
 const images = path.resolve(assets, 'images');
 const fonts = path.resolve(assets, 'fonts');
-const rebrand = path.resolve(assets, 'rebrand');
 
 const copyGovukTemplateAssets = new CopyWebpackPlugin({
   patterns: [
     { from: images, to: 'assets/images' },
     { from: fonts, to: 'assets/fonts' },
-    { from: rebrand, to: 'assets/rebrand' },
     { from: `${assets}/manifest.json`, to: 'assets' },
     { from: `${root}/template.njk`, to: '../views/govuk' },
     { from: `${root}/components`, to: '../views/govuk/components' },


### PR DESCRIPTION
### Jira link

House Keeping

### Change description
Unbreaks the master build after a batch of Renovate major bumps (prettier 3.9.4, typescript v6, totp-generator v2, govuk-frontend v6).
Fixes lint (reformat), unit-test + prod-build TS errors, and the govuk v6 webpack asset copy — config/code only, no behaviour change.


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist


- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
