### PR TITLE
Revert restriction on Demo deployments

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,6 +34,8 @@ withPipeline(type, product, component) {
   def githubApi = new GithubAPI(this)
   loadVaultSecrets(secrets)
 
+  syncBranchesWithMaster(['ithc', 'perftest', 'demo'])
+
   env.NODE_CONFIG_ENV = 'test'
   env.PCS_API_URL = "http://pcs-api-aat.service.core-compute-aat.internal"
   env.DATA_STORE_URL_BASE = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,8 +34,6 @@ withPipeline(type, product, component) {
   def githubApi = new GithubAPI(this)
   loadVaultSecrets(secrets)
 
-  syncBranchesWithMaster(['ithc', 'perftest'])
-
   env.NODE_CONFIG_ENV = 'test'
   env.PCS_API_URL = "http://pcs-api-aat.service.core-compute-aat.internal"
   env.DATA_STORE_URL_BASE = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"


### PR DESCRIPTION
### Change description

Reverts the temporary suspension of deployments to Demo, now that the necessary testing is complete.

Original PR: https://github.com/hmcts/pcs-frontend/pull/1709/changes

### Testing done

n/a

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Feature flag assessment

**Feature flag:** Does this PR introduce or change user-facing behaviour that should be behind feature flag(s)?

- [ ] Yes — flag(s):
- [x] No — reason:

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
