### PR TITLE
HDPI-8155: raise redis probe budgets on preview for Dynatrace overhead

### DIFF
--- a/charts/pcs-frontend/values.preview.template.yaml
+++ b/charts/pcs-frontend/values.preview.template.yaml
@@ -26,6 +26,16 @@ redis:
     registry: hmctsprod.azurecr.io
     repository: imported/bitnami/redis
   enabled: true
+  master:
+    # HDPI-8155: Dynatrace node instrumentation on preview adds ~1s per
+    # spawned process; the chart-default 2s exec-probe budget leaves redis
+    # permanently Running-but-not-Ready (frontends then ECONNREFUSED :6379).
+    # Measured probe wall time under instrumentation: 3.4-4.1s.
+    readinessProbe:
+      timeoutSeconds: 6
+      periodSeconds: 10
+    livenessProbe:
+      timeoutSeconds: 8
 global:
   security:
     allowInsecureImages: true


### PR DESCRIPTION
### What
`values.preview.template.yaml`: redis master readiness probe `timeoutSeconds` 2 -> 6 (period 10), liveness 8.

### Why
All preview frontend deploys failing since ~20:00 5 Aug (QA blocked). Verified chain: Dynatrace rollout on cft-preview-00 -> per-process instrumentation overhead -> bitnami redis readiness exec probe now takes 3.4-4.1s wall (0.2s CPU) against a 2s budget -> redis Running-but-never-Ready -> no Service endpoints -> frontends `ECONNREFUSED :6379` -> CrashLoop -> helm rollout timeout.

Cluster-side STS patches (2->6) brought 18/18 redis Ready and frontends back - and PR-1854's rebuild immediately reverted the patch, proving the chart is the only durable home for this.

### Validation
This PR's own preview deploy: redis Ready within one probe period, nodejs pods Ready, AKS deploy stage green.

Platform follow-up on HDPI-8155: PlatOps/Praveen to consider DynaKube exclusion for data-store pods; any chart on this cluster with exec probes under ~4s is at risk.