### PR TITLE
Fix: prevent preview deploys hanging on Redis readiness (bump probe timeout)

### DIFF
--- a/charts/pcs-frontend/values.preview.template.yaml
+++ b/charts/pcs-frontend/values.preview.template.yaml
@@ -26,6 +26,11 @@ redis:
     registry: hmctsprod.azurecr.io
     repository: imported/bitnami/redis
   enabled: true
+  master:
+    readinessProbe:
+      timeoutSeconds: 10
+    livenessProbe:
+      timeoutSeconds: 10
 global:
   security:
     allowInsecureImages: true


### PR DESCRIPTION
## Problem

Preview builds (e.g. PR-1796) hung for ~20 min at `aks deploy: helm upgrade → wait for install`, then failed. The `kubectl wait --for=condition=ready` never returned.

### Root cause

- The bitnami redis subchart (v27.0.18) pulls `imported/bitnami/redis:latest`, which has drifted to the Redis 8.4.0 redis-stack image (RediSearch/ReJSON modules loaded at boot).
- On that heavier image the readiness script `ping_readiness_local.sh` takes ~3.4s, but the subchart's default probe timeoutSeconds is 1s, so the probe timed out on every cycle.
- Redis stayed `0/1 NotReady` → dropped from the `-redis-master` Service (zero endpoints) → the frontend couldn't reach Redis → ioredis exhausted its 20 retries → the Node app exited 1 → port 3209 never bound → all pod probes failed → `kubectl wait` hung to timeout → build stuck.

Redis itself was healthy the whole time (PONG, "Ready to accept connections"); the probe was simply too tight for this image.

### Fix

Override the Redis master probe timeouts in values.preview.template.yaml:

`redis:
  master:
    readinessProbe:
      timeoutSeconds: 10
    livenessProbe:
      timeoutSeconds: 10`

